### PR TITLE
chore: add issue templates and pr template

### DIFF
--- a/.github/issue_template/bug.md
+++ b/.github/issue_template/bug.md
@@ -1,0 +1,22 @@
+---
+name: Bug
+about: Something is broken
+labels: bug
+title: "[Bug] "
+---
+
+## Overview
+<!-- What did you expect vs what actually happened? -->
+
+## Steps to reproduce
+<!-- Provide clear steps to reproduce the issue -->
+1.
+2.
+
+## Tasks
+<!-- Break down into smaller, actionable tasks -->
+- [ ]
+
+## Acceptance criteria
+<!-- Define what "done" looks like -->
+- [ ]

--- a/.github/issue_template/enhancement.md
+++ b/.github/issue_template/enhancement.md
@@ -1,0 +1,17 @@
+---
+name: Enhancement
+about: Improve something that already exists
+labels: enhancement
+title: "[Enhancement] "
+---
+
+## Overview
+<!-- What exists today and what should change? -->
+
+## Tasks
+<!-- Break down into smaller, actionable tasks -->
+- [ ]
+
+## Acceptance criteria
+<!-- Define what "done" looks like -->
+- [ ]

--- a/.github/issue_template/feature.md
+++ b/.github/issue_template/feature.md
@@ -1,0 +1,17 @@
+---
+name: Feature
+about: New functionality to build
+labels: feature
+title: "[Feature] "
+---
+
+## Overview
+<!-- What are we building and why? -->
+
+## Tasks
+<!-- Break down into smaller, actionable tasks -->
+- [ ]
+
+## Acceptance criteria
+<!-- Define what "done" looks like -->
+- [ ]

--- a/.github/issue_template/task.md
+++ b/.github/issue_template/task.md
@@ -1,0 +1,17 @@
+---
+name: Task
+about: Technical work, setup, refactor, or chore
+labels: task
+title: "[Task] "
+---
+
+## Overview
+<!-- What needs to be done and why? -->
+
+## Tasks
+<!-- Break down into smaller, actionable tasks -->
+- [ ]
+
+## Acceptance criteria
+<!-- Define what "done" looks like -->
+- [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Related issue
+<!-- Link the issue this PR addresses -->
+Closes #[issue-number]
+
+## What changed
+<!-- Brief description of what was added or modified -->
+-
+
+## How to test
+<!-- Steps to verify the changes -->
+-


### PR DESCRIPTION
## Related issue
<!-- Link the issue this PR addresses -->
Closes #8 

## What changed
<!-- Brief description of what was added or modified -->
- Created `feature`, `task`, `bug`, `enhancement` and `pull_request` templates

## How to test
<!-- Steps to verify the changes -->
- Once merged:
  - Selecting an issue type pre-fills the correct template and title prefix
  - Opening a new PR auto-loads the pull request template
