### PR TITLE
fix: clear refresh_token at both cookie paths on logout and OAuth login

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,22 +12,17 @@ const nextConfig: NextConfig = {
     if (!upstream) throw new Error("BACKEND_API_URL is required");
 
     return {
-      // beforeFiles: proxy specific backend auth paths BEFORE Next.js resolves the
-      // [...nextauth] catch-all. This ensures otp/logout calls reach the API,
-      // while NextAuth's own session/signin/callback routes are left untouched.
-      //
-      // /api/auth/token and /api/auth/token/refresh are intentionally omitted here —
-      // they are handled by dedicated route handlers that re-set the refresh-token
-      // cookie with path="/" so the middleware can read it on all routes.
+      // beforeFiles: run before Next.js file-system routing
+      // /api/auth/token, /api/auth/token/refresh, and /api/auth/logout are omitted —
+      // they have dedicated route handlers that manage the refresh-token cookie
       beforeFiles: [
         { source: "/api/auth/otp/:path*", destination: `${upstream}/api/auth/otp/:path*` },
         { source: "/api/auth/logout/all", destination: `${upstream}/api/auth/logout/all` },
-        { source: "/api/auth/logout", destination: `${upstream}/api/auth/logout` },
         { source: "/api/auth/sessions", destination: `${upstream}/api/auth/sessions` },
         { source: "/api/oauth/:path*", destination: `${upstream}/api/oauth/:path*` },
       ],
 
-      // afterFiles: proxy non-auth API routes to the backend.
+      // afterFiles: proxy non-auth API routes to the backend
       // Excludes paths owned by custom route handlers (e.g. matches/:id/pick) —
       // afterFiles rewrites run before dynamic routes, so a match here would swallow them
       afterFiles: [{ source: "/api/:path((?!auth/|matches/[^/]+/pick).*)", destination: `${upstream}/api/:path*` }],

--- a/src/app/api/auth/_lib/token-proxy.ts
+++ b/src/app/api/auth/_lib/token-proxy.ts
@@ -14,8 +14,10 @@ export function forwardedClientHeaders(req: NextRequest): Record<string, string>
   return headers;
 }
 
-// Extracts the refresh token from the upstream Set-Cookie header and re-sets it
-// with path="/" so it travels on every browser request, not only /api/auth ones.
+// Re-sets the refresh-token cookie at path="/" so it is visible on every route.
+// Also clears the backend's natural Path=/api/auth copy — the Google OAuth callback
+// sets it there directly (browser ← backend redirect, bypasses Next.js), and only
+// this BFF rewrite can clean it up proactively on the next token operation
 export function rewriteRefreshCookie(header: string | null, res: NextResponse): void {
   if (!header) return;
   const valueMatch = new RegExp(`^${REFRESH_COOKIE}=([^;]+)`).exec(header.trim());
@@ -28,4 +30,10 @@ export function rewriteRefreshCookie(header: string | null, res: NextResponse): 
     path: "/",
     ...(expiresMatch?.[1] && { expires: new Date(expiresMatch[1]) }),
   });
+
+  // Clear the Path=/api/auth copy. Use headers.append — cookies.set is keyed by
+  // name only, so a second call for the same cookie name at a different path
+  // would silently clobber the set above
+  const secureSuffix = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  res.headers.append("Set-Cookie", `${REFRESH_COOKIE}=; Path=/api/auth; Max-Age=0; HttpOnly; SameSite=Lax${secureSuffix}`);
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { forwardedClientHeaders, REFRESH_COOKIE, UPSTREAM } from "../_lib/token-proxy";
+
+// The backend sets the cookie at Path=/api/auth; the BFF rewrites it to Path=/.
+// Both must be cleared on logout — the upstream directive only covers its own path
+const REFRESH_COOKIE_PATHS = ["/", "/api/auth"] as const;
+export async function POST(req: NextRequest) {
+  const cookieHeader = req.headers.get("cookie");
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${UPSTREAM}/api/auth/logout`, {
+      method: "POST",
+      headers: {
+        ...(cookieHeader && { Cookie: cookieHeader }),
+        ...forwardedClientHeaders(req),
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: { code: "NETWORK_ERROR", message: "Upstream unreachable" } }, { status: 502 });
+  }
+
+  const body = await upstream.text();
+  const res = body.length > 0 ? new NextResponse(body, { status: upstream.status }) : new NextResponse(null, { status: upstream.status });
+
+  // Use headers.append, not cookies.set — the cookies API is keyed by name only,
+  // so two calls for the same cookie at different paths would clobber each other
+  const secureSuffix = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  for (const path of REFRESH_COOKIE_PATHS) {
+    res.headers.append("Set-Cookie", `${REFRESH_COOKIE}=; Path=${path}; Max-Age=0; HttpOnly; SameSite=Lax${secureSuffix}`);
+  }
+
+  return res;
+}


### PR DESCRIPTION
## Related issue

N/A

## What changed

- Add BFF logout route handler (`src/app/api/auth/logout/route.ts`) that clears `refresh_token` at both `Path=/` and `Path=/api/auth` on sign-out
- Remove `/api/auth/logout` from `beforeFiles` rewrites so the new route handler runs instead of proxying directly
- Clear `Path=/api/auth` cookie in `rewriteRefreshCookie` on every token operation — fixes the double-cookie left by Google OAuth's direct backend redirect

## How to test

- [ ] Sign in with Google, open DevTools → Application → Cookies — only one `refresh_token` cookie at `Path=/` should exist
- [ ] Sign out — both `refresh_token` cookies (if any) should be cleared from the browser jar
- [ ] Sign in again after sign-out — no stale token errors, session starts clean
- [ ] Sign in with OTP — single `refresh_token` at `Path=/`, sign-out clears it