### PR TITLE
feat(pickems): CTA helper text, progress bar, cross-device prune

### DIFF
--- a/i18n/messages/pickems/en.json
+++ b/i18n/messages/pickems/en.json
@@ -7,14 +7,17 @@
     "2": "Best thirds",
     "3": "Bracket"
   },
-  "stepCrumb": "Step {n} of {total}",
   "common": {
     "back": "Back",
     "continue": "Continue",
     "continueToStep2": "Step 2",
     "continueToStep3": "Step 3",
     "saveDraft": "Save draft",
-    "saving": "Saving..."
+    "saving": "Saving...",
+    "readyForStep2": "All set, continue to step 2",
+    "readyForStep3": "All set, continue to step 3",
+    "readyForRound": "All set, continue to {round}",
+    "readyToSubmit": "All set, submit your picks"
   },
   "groups": {
     "title": "Predict the group stage",
@@ -29,6 +32,7 @@
     "groupLabel": "Group {code}",
     "lockAction": "Lock group {code}",
     "unlockAction": "Unlock group {code}",
+    "lockedCount": "{completed} of {total} groups locked",
     "badges": {
       "qualify": "Q",
       "third": "3rd",
@@ -37,7 +41,7 @@
   },
   "bestThirds": {
     "title": "Best third-place teams",
-    "subtitle": "From the 12 third-placed sides above, pick the {total} you think will advance to the Round of 32.",
+    "subtitle": "From your 12 third-place teams, pick the {total} you think will advance to the Round of 32.",
     "moreNeeded": "{n, plural, one {# more selection needed} other {# more selections needed}}",
     "groupTag": "Group {code}"
   },
@@ -66,7 +70,8 @@
       "final": "Final"
     },
     "roundLeft": "{n} left",
-    "pickRoundCount": "Pick {n} winners"
+    "pickRoundCount": "Pick {n} winners",
+    "roundComplete": "Round complete"
   },
   "toasts": {
     "groupsSaved": "Groups saved",
@@ -78,6 +83,9 @@
     "groupLocked": "Group {code} locked",
     "groupUnlocked": "Group {code} unlocked",
     "saveFailed": "Could not save. Try again.",
-    "submitFailed": "Could not submit your bracket. Try again."
+    "submitFailed": "Could not submit your bracket. Try again.",
+    "lockAllGroupsFirst": "Lock all 12 groups before continuing",
+    "selectAllThirdsFirst": "Pick all 8 best thirds before continuing",
+    "finishRoundFirst": "Finish this round before continuing"
   }
 }

--- a/i18n/messages/pickems/es.json
+++ b/i18n/messages/pickems/es.json
@@ -7,14 +7,17 @@
     "2": "Mejores terceros",
     "3": "Eliminatoria"
   },
-  "stepCrumb": "Paso {n} de {total}",
   "common": {
     "back": "Atrás",
     "continue": "Continuar",
     "continueToStep2": "Paso 2",
     "continueToStep3": "Paso 3",
     "saveDraft": "Guardar borrador",
-    "saving": "Guardando..."
+    "saving": "Guardando...",
+    "readyForStep2": "Todo listo, continúa al paso 2",
+    "readyForStep3": "Todo listo, continúa al paso 3",
+    "readyForRound": "Todo listo, continúa a {round}",
+    "readyToSubmit": "Todo listo, envía tus picks"
   },
   "groups": {
     "title": "Pronostica la fase de grupos",
@@ -29,6 +32,7 @@
     "groupLabel": "Grupo {code}",
     "lockAction": "Bloquear grupo {code}",
     "unlockAction": "Desbloquear grupo {code}",
+    "lockedCount": "{completed} de {total} grupos confirmados",
     "badges": {
       "qualify": "Q",
       "third": "3°",
@@ -37,7 +41,7 @@
   },
   "bestThirds": {
     "title": "Mejores terceros",
-    "subtitle": "De los 12 equipos en tercer lugar, elige los {total} que crees que pasarán a Octavos de Final.",
+    "subtitle": "De tus 12 terceros, elige los {total} que pasarán a Octavos de Final.",
     "moreNeeded": "{n, plural, one {Falta # selección} other {Faltan # selecciones}}",
     "groupTag": "Grupo {code}"
   },
@@ -66,7 +70,8 @@
       "final": "Final"
     },
     "roundLeft": "Faltan {n}",
-    "pickRoundCount": "Elige {n} ganadores"
+    "pickRoundCount": "Elige {n} ganadores",
+    "roundComplete": "Ronda completa"
   },
   "toasts": {
     "groupsSaved": "Grupos guardados",
@@ -78,6 +83,9 @@
     "groupLocked": "Grupo {code} bloqueado",
     "groupUnlocked": "Grupo {code} desbloqueado",
     "saveFailed": "No se pudo guardar. Inténtalo de nuevo.",
-    "submitFailed": "No se pudo enviar tu llave. Inténtalo de nuevo."
+    "submitFailed": "No se pudo enviar tu llave. Inténtalo de nuevo.",
+    "lockAllGroupsFirst": "Confirma los 12 grupos antes de continuar",
+    "selectAllThirdsFirst": "Elige los 8 mejores terceros antes de continuar",
+    "finishRoundFirst": "Termina esta ronda antes de continuar"
   }
 }

--- a/src/app/pickems/layout.tsx
+++ b/src/app/pickems/layout.tsx
@@ -1,6 +1,19 @@
 export default function PickemsLayout({ children }: { children: React.ReactNode }) {
   return (
     <div data-accent="blue" className="contents">
+      {/* Route-scoped offsets so the mobile CTA bar doesn't sit on top of the
+          global footer or sonner toasts. The bar measures itself and writes
+          --pickems-cta-height on <body>, so padding matches the bar exactly
+          (no gap below the footer). The static fallback covers the first paint
+          before the effect runs and the locked-state case (no bar rendered). */}
+      <style>{`
+        @media (max-width: 1023.98px) {
+          body { padding-bottom: var(--pickems-cta-height, calc(7rem + env(safe-area-inset-bottom))); }
+          [data-sonner-toaster][data-y-position="bottom"] {
+            bottom: var(--pickems-cta-height, calc(7rem + env(safe-area-inset-bottom))) !important;
+          }
+        }
+      `}</style>
       {children}
     </div>
   );

--- a/src/features/pickems/components/BracketChampionCard.tsx
+++ b/src/features/pickems/components/BracketChampionCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Trophy } from "lucide-react";
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 
@@ -16,27 +17,39 @@ export function BracketChampionCard({ champion, className }: Props) {
   const t = useTranslations("pickems.bracket");
   const locale = useLocale();
 
+  if (!champion) {
+    return (
+      <div className={cn("flex flex-col gap-2", className)}>
+        <div className="flex min-h-24 flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed border-border bg-card px-4 py-5">
+          <span className="font-mono text-2xs font-semibold uppercase tracking-[0.2em] text-muted-foreground/70">{t("champion")}</span>
+          <p className="text-center text-xs text-muted-foreground">{t("pickFinalWinner")}</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={cn("flex flex-col gap-2", className)}>
       <div
         className={cn(
-          "flex min-h-24 flex-col items-center justify-center gap-2 rounded-md border-2 bg-card px-4 py-5",
-          champion ? "border-page-accent" : "border-dashed border-border"
+          "flex flex-col items-center justify-center gap-4 rounded-md border-2 bg-card px-4 py-6",
+          "border-amber-400/70 dark:border-amber-500/50",
+          "animate-in fade-in zoom-in-95 duration-500"
         )}
       >
-        <span className={cn("font-mono text-2xs font-semibold uppercase tracking-[0.2em]", champion ? "text-page-accent-strong" : "text-muted-foreground/70")}>
-          {t("champion")}
-        </span>
-        {champion ? (
-          <div className="flex w-full items-center justify-center gap-2.5">
-            <div className="shrink-0 overflow-hidden rounded-xs ring-1 ring-border/60">
-              <Image src={champion.flag_url} alt="" width={36} height={24} sizes="36px" className="h-6 w-9 object-cover" />
-            </div>
-            <span className="min-w-0 truncate text-base font-semibold text-foreground">{getTeamName(champion, locale)}</span>
+        <div className="flex flex-col items-center gap-1.5">
+          <div className="flex size-10 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-500/15">
+            <Trophy className="size-5 text-amber-600 dark:text-amber-400" strokeWidth={2.25} aria-hidden />
           </div>
-        ) : (
-          <p className="text-center text-xs text-muted-foreground">{t("pickFinalWinner")}</p>
-        )}
+          <span className="font-mono text-2xs font-semibold uppercase tracking-[0.25em] text-amber-700 dark:text-amber-500">{t("champion")}</span>
+        </div>
+
+        <div className="flex w-full items-center justify-center gap-2.5">
+          <div className="shrink-0 overflow-hidden rounded-xs ring-1 ring-border/60">
+            <Image src={champion.flag_url} alt="" width={36} height={24} sizes="36px" className="h-6 w-9 object-cover" />
+          </div>
+          <span className="min-w-0 truncate text-lg font-semibold tracking-tight text-foreground">{getTeamName(champion, locale)}</span>
+        </div>
       </div>
     </div>
   );

--- a/src/features/pickems/components/BracketDesktop.tsx
+++ b/src/features/pickems/components/BracketDesktop.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Trophy } from "lucide-react";
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 
@@ -283,35 +284,37 @@ type ChampionDisplayProps = {
 };
 
 /**
- * Always-rendered "Champion" slot in the center column. Filled state shows
- * the accent label on top + flag + team name; empty state collapses to just
- * the muted label with a dashed border. Same `min-h` either way — picking the
- * champion swaps the card's content without nudging Final / Third downward.
- *
- * No trophy iconography — the accent border, accent label, and prominent flag
- * carry the "winner" treatment with a cleaner editorial feel.
+ * Always-rendered "Champion" slot in the center column. Same `min-h` filled vs.
+ * empty so picking the champion swaps content without nudging Final / Third.
  */
 function BracketChampionDisplay({ champion, label, locale }: ChampionDisplayProps) {
-  const filled = champion !== null;
+  if (!champion) {
+    return (
+      <div className="flex min-h-28 flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed border-border bg-card px-2 py-2.5">
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/70">{label}</span>
+      </div>
+    );
+  }
   return (
     <div
       className={cn(
-        "flex min-h-28 flex-col items-center justify-center gap-2 rounded-md bg-card px-2 py-2.5",
-        filled ? "border-2 border-page-accent" : "border-2 border-dashed border-border"
+        "flex min-h-28 flex-col items-center justify-center gap-1.5 rounded-md border-2 bg-card px-2 py-2.5",
+        "border-amber-400/70 dark:border-amber-500/50",
+        "animate-in fade-in zoom-in-95 duration-500"
       )}
     >
-      <span className={cn("font-mono text-[10px] font-semibold uppercase tracking-[0.2em]", filled ? "text-page-accent-strong" : "text-muted-foreground/70")}>
-        {label}
-      </span>
-
-      {filled && (
-        <div className="flex w-full flex-col items-center gap-1">
-          <div className="overflow-hidden rounded-xs ring-1 ring-border/60">
-            <Image src={champion.flag_url} alt="" width={40} height={28} sizes="40px" className="h-5 w-7 object-cover" />
-          </div>
-          <span className="max-w-full truncate text-sm font-semibold text-foreground">{getTeamName(champion, locale)}</span>
+      <div className="flex flex-col items-center gap-1">
+        <div className="flex size-7 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-500/15">
+          <Trophy className="size-3.5 text-amber-600 dark:text-amber-400" strokeWidth={2.25} aria-hidden />
         </div>
-      )}
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.25em] text-amber-700 dark:text-amber-500">{label}</span>
+      </div>
+      <div className="flex w-full flex-col items-center gap-1">
+        <div className="overflow-hidden rounded-xs ring-1 ring-border/60">
+          <Image src={champion.flag_url} alt="" width={28} height={20} sizes="28px" className="h-5 w-7 object-cover" />
+        </div>
+        <span className="max-w-full truncate text-sm font-semibold tracking-tight text-foreground">{getTeamName(champion, locale)}</span>
+      </div>
     </div>
   );
 }

--- a/src/features/pickems/components/BracketMatchCard.tsx
+++ b/src/features/pickems/components/BracketMatchCard.tsx
@@ -106,7 +106,11 @@ function TeamRow({ team, picked, density, locale, canPick, onPick }: TeamRowProp
       aria-pressed={picked}
     >
       <div className="shrink-0 overflow-hidden rounded-xs ring-1 ring-border/60">
-        <Image src={team.flag_url} alt="" width={32} height={22} sizes="32px" className={cn("object-cover", density === "dense" ? "h-3.5 w-5" : "h-5 w-8")} />
+        {density === "dense" ? (
+          <Image src={team.flag_url} alt="" width={20} height={14} sizes="20px" className="h-3.5 w-5 object-cover" />
+        ) : (
+          <Image src={team.flag_url} alt="" width={32} height={20} sizes="32px" className="h-5 w-8 object-cover" />
+        )}
       </div>
       <span className={cn("min-w-0 flex-1 truncate text-foreground", density === "dense" ? "text-xs" : "text-sm", picked ? "font-semibold" : "font-medium")}>
         {getTeamName(team, locale)}

--- a/src/features/pickems/components/BracketMobile.tsx
+++ b/src/features/pickems/components/BracketMobile.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Check } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { cn } from "@/shared/lib/utils";
@@ -45,6 +46,8 @@ export function BracketMobile({ bracket, champion, disabled, onPick, activeStage
         <div className="grid grid-cols-6 gap-1 rounded-xl border bg-card p-1">
           {tabsMeta.map((meta) => {
             const isActive = meta.stage === activeStage;
+            const isComplete = meta.completed === meta.total;
+            const showCheck = isComplete && !isActive;
             return (
               <button
                 key={meta.stage}
@@ -56,9 +59,13 @@ export function BracketMobile({ bracket, champion, disabled, onPick, activeStage
                 )}
               >
                 <div>{tShort(meta.stage)}</div>
-                <div className={cn("font-mono text-2xs uppercase tracking-wider", isActive ? "text-white/75" : "text-muted-foreground")}>
-                  {meta.completed}/{meta.total}
-                </div>
+                {showCheck ? (
+                  <Check className="mx-auto mt-0.5 size-3 text-page-accent-strong" aria-label={t("roundComplete")} />
+                ) : (
+                  <div className={cn("font-mono text-2xs uppercase tracking-wider", isActive ? "text-white/75" : "text-muted-foreground")}>
+                    {meta.completed}/{meta.total}
+                  </div>
+                )}
               </button>
             );
           })}

--- a/src/features/pickems/components/GroupCard.tsx
+++ b/src/features/pickems/components/GroupCard.tsx
@@ -54,7 +54,7 @@ export function GroupCard({ group, onReorder, disabled, onToggleLock, isLocking,
   };
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border bg-card">
+    <div className={cn("overflow-hidden rounded-xl border bg-card transition-colors", group.locked ? "border-page-accent/40 bg-page-accent-soft/25" : "border-border")}>
       <button
         type="button"
         onClick={onToggle}
@@ -88,11 +88,11 @@ export function GroupCard({ group, onReorder, disabled, onToggleLock, isLocking,
           }}
           className={cn(
             "hidden md:ml-auto md:inline-flex md:size-7 md:shrink-0 md:cursor-pointer md:items-center md:justify-center md:rounded-md md:transition-colors md:pointer-events-auto",
-            group.locked ? "md:bg-page-accent-soft md:text-page-accent-strong md:hover:bg-page-accent-soft/80" : "md:text-muted-foreground md:hover:bg-muted",
+            group.locked ? "md:bg-page-accent-soft md:text-page-accent-strong md:hover:bg-page-accent-soft/80" : "md:text-foreground md:hover:bg-muted",
             (disabled || isLocking) && "md:cursor-not-allowed md:opacity-50 md:hover:bg-transparent"
           )}
         >
-          {group.locked ? <Lock className="size-4" aria-hidden /> : <LockOpen className="size-4" aria-hidden />}
+          {group.locked ? <Lock className="size-4" aria-hidden /> : <LockOpen className="size-4" strokeWidth={2.25} aria-hidden />}
         </span>
 
         <span
@@ -111,11 +111,11 @@ export function GroupCard({ group, onReorder, disabled, onToggleLock, isLocking,
           }}
           className={cn(
             "ml-1 inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors md:hidden",
-            group.locked ? "bg-page-accent-soft text-page-accent-strong hover:bg-page-accent-soft/80" : "text-muted-foreground hover:bg-muted",
+            group.locked ? "bg-page-accent-soft text-page-accent-strong hover:bg-page-accent-soft/80" : "text-foreground hover:bg-muted",
             (disabled || isLocking) && "cursor-not-allowed opacity-50 hover:bg-transparent"
           )}
         >
-          {group.locked ? <Lock className="size-4" aria-hidden /> : <LockOpen className="size-4" aria-hidden />}
+          {group.locked ? <Lock className="size-4" aria-hidden /> : <LockOpen className="size-4" strokeWidth={2.25} aria-hidden />}
         </span>
 
         <ChevronDown className={cn("ml-2 size-4 shrink-0 text-muted-foreground transition-transform md:hidden", open && "rotate-180")} aria-hidden />

--- a/src/features/pickems/components/GroupTeamRow.tsx
+++ b/src/features/pickems/components/GroupTeamRow.tsx
@@ -45,9 +45,9 @@ export function GroupTeamRow({ team, position, locale, disabled }: Props) {
       {...(disabled ? {} : attributes)}
       {...(disabled ? {} : listeners)}
       className={cn(
-        "flex items-center gap-3 rounded-lg border border-border px-2.5 py-2 outline-none transition-shadow touch-none select-none",
+        "flex items-center gap-3 rounded-lg border border-border px-2.5 py-2 outline-none transition-shadow select-none",
         rowBgClass,
-        !disabled && "cursor-grab focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing",
+        !disabled && "touch-none cursor-grab focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing",
         isDragging && "z-10 shadow-md"
       )}
     >

--- a/src/features/pickems/components/PickemsCTABar.tsx
+++ b/src/features/pickems/components/PickemsCTABar.tsx
@@ -1,34 +1,84 @@
 "use client";
 
-import { ArrowLeft, ArrowRight, CloudUpload, Loader2 } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { ArrowLeft, ArrowRight, CheckCircle2, CloudUpload, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/shared/components/ui/button";
+import { cn } from "@/shared/lib/utils";
 
 export type CTAAction =
   | { kind: "hidden" }
-  | { kind: "continue"; label?: string; disabled?: boolean; loading?: boolean; helperText?: string; onClick: () => void }
-  | { kind: "submit"; label?: string; disabled?: boolean; loading?: boolean; helperText?: string; onClick: () => void };
+  | { kind: "continue"; label?: string; disabled?: boolean; loading?: boolean; helperText?: string; helperTone?: "ready"; onClick: () => void }
+  | { kind: "submit"; label?: string; disabled?: boolean; loading?: boolean; helperText?: string; helperTone?: "ready"; onClick: () => void };
 
 type Props = {
   onBack?: () => void;
   onSaveDraft?: () => void;
   action: CTAAction;
+  progress?: { completed: number; total: number };
 };
 
-export function PickemsCTABar({ onBack, onSaveDraft, action }: Props) {
+export function PickemsCTABar({ onBack, onSaveDraft, action, progress }: Props) {
   const t = useTranslations("pickems.common");
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Expose the bar's measured height (incl. safe-area padding) as a CSS var so
+  // the route layout can match body padding-bottom to it exactly — otherwise a
+  // static padding value leaves a visible gap between the global footer and
+  // the bar whenever the bar is shorter than the reserved space.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const write = () => document.body.style.setProperty("--pickems-cta-height", `${el.offsetHeight}px`);
+    write();
+    const ro = new ResizeObserver(write);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      document.body.style.removeProperty("--pickems-cta-height");
+    };
+  }, []);
 
   if (action.kind === "hidden" && !onBack && !onSaveDraft) return null;
 
   const spinner = <Loader2 className="size-4 animate-spin" aria-label={t("saving")} />;
+  const helperText = action.kind !== "hidden" ? action.helperText : undefined;
+  const helperTone = action.kind !== "hidden" ? action.helperTone : undefined;
+  const showProgress = !!progress && progress.total > 0;
+  const percent = progress && progress.total > 0 ? Math.min(100, (progress.completed / progress.total) * 100) : 0;
+
+  // `disabled` = muted but still clickable (handler shows a toast). `loading` = HTML-disabled + spinner.
+  const isGated = action.kind !== "hidden" && !!action.disabled && !action.loading;
+  const isLoading = action.kind !== "hidden" && !!action.loading;
+  const gatedClass = isGated && "opacity-50 hover:bg-page-accent";
 
   return (
     <div
+      ref={ref}
       className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-background py-3 lg:hidden"
       style={{ paddingBottom: "calc(0.75rem + env(safe-area-inset-bottom))" }}
     >
-      {action.kind !== "hidden" && action.helperText && <p className="container pb-2 text-center text-2xs text-muted-foreground">{action.helperText}</p>}
+      {(helperText || showProgress) && (
+        <div className="container space-y-1.5 pb-2">
+          {helperText && (
+            <p
+              className={cn(
+                "flex items-center justify-center gap-1.5 text-center text-xs font-medium",
+                helperTone === "ready" ? "text-page-accent-strong" : "text-muted-foreground"
+              )}
+            >
+              {helperTone === "ready" && <CheckCircle2 className="size-3.5 shrink-0" aria-hidden />}
+              <span>{helperText}</span>
+            </p>
+          )}
+          {showProgress && (
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+              <div className="h-full bg-page-accent transition-all" style={{ width: `${percent}%` }} />
+            </div>
+          )}
+        </div>
+      )}
       <div className="container flex items-center gap-2">
         {onBack && (
           <Button variant="outline" size="sm" onClick={onBack} className="h-10 flex-1 cursor-pointer gap-1.5">
@@ -46,10 +96,11 @@ export function PickemsCTABar({ onBack, onSaveDraft, action }: Props) {
           <Button
             size="sm"
             onClick={action.onClick}
-            disabled={action.disabled || action.loading}
-            className="h-10 flex-1 cursor-pointer gap-1.5 bg-page-accent text-white hover:bg-page-accent/90"
+            aria-disabled={isGated}
+            disabled={isLoading}
+            className={cn("h-10 flex-1 cursor-pointer gap-1.5 bg-page-accent text-white hover:bg-page-accent/90", gatedClass)}
           >
-            {action.loading ? (
+            {isLoading ? (
               spinner
             ) : (
               <>
@@ -63,10 +114,11 @@ export function PickemsCTABar({ onBack, onSaveDraft, action }: Props) {
           <Button
             size="sm"
             onClick={action.onClick}
-            disabled={action.disabled || action.loading}
-            className="h-10 flex-1 cursor-pointer bg-page-accent text-white hover:bg-page-accent/90"
+            aria-disabled={isGated}
+            disabled={isLoading}
+            className={cn("h-10 flex-1 cursor-pointer bg-page-accent text-white hover:bg-page-accent/90", gatedClass)}
           >
-            {action.loading ? spinner : (action.label ?? t("continue"))}
+            {isLoading ? spinner : (action.label ?? t("continue"))}
           </Button>
         )}
       </div>

--- a/src/features/pickems/components/PickemsHeader.tsx
+++ b/src/features/pickems/components/PickemsHeader.tsx
@@ -18,20 +18,12 @@ export function PickemsHeader({ step, rightSlot, className }: Props) {
   return (
     <div className={cn("flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between", className)}>
       <div className="min-w-0 flex-1 space-y-1">
-        <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-          {t("title")} · {stepCrumb(step, t)}
-        </p>
         <h2 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">{stepTitle(step, t)}</h2>
         <p className="text-sm text-muted-foreground">{stepSubtitle(step, t)}</p>
       </div>
       {rightSlot && <div className="hidden flex-wrap items-center justify-end gap-3 sm:flex sm:flex-col sm:items-end">{rightSlot}</div>}
     </div>
   );
-}
-
-function stepCrumb(step: PickemStep, t: ReturnType<typeof useTranslations>) {
-  const idx = step === "groups" ? 1 : step === "thirds" ? 2 : 3;
-  return t("stepCrumb", { n: idx, total: 3 });
 }
 
 function stepTitle(step: PickemStep, t: ReturnType<typeof useTranslations>) {

--- a/src/features/pickems/components/PickemsHeaderActions.tsx
+++ b/src/features/pickems/components/PickemsHeaderActions.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, ArrowRight, CloudUpload, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/shared/components/ui/button";
+import { cn } from "@/shared/lib/utils";
 
 import type { CTAAction } from "./PickemsCTABar";
 
@@ -14,30 +15,33 @@ type Props = {
 };
 
 /**
- * Inline action buttons rendered in the page header on desktop. Mobile uses
- * the fixed-bottom `PickemsCTABar` instead — this component hides itself
- * below `lg:`.
+ * Inline action buttons rendered in the page header on desktop. Visibility is
+ * controlled by the parent rail wrapper (which also lines up the progress bar
+ * underneath these buttons).
  */
 export function PickemsHeaderActions({ onBack, onSaveDraft, action }: Props) {
   const t = useTranslations("pickems.common");
 
   if (action.kind === "hidden" && !onBack && !onSaveDraft) return null;
 
-  // Spinner-not-text: the button's `min-w-*` only enforces a *minimum*, so a
-  // "Guardando..." label was wider than "Paso 2 →" and made the button grow
-  // visibly on every lock click. A fixed-size icon keeps width stable.
+  // Fixed-width buttons + a fixed-size spinner keep the row from reflowing when
+  // labels swap to longer locales or the saving state kicks in.
   const spinner = <Loader2 className="size-4 animate-spin" aria-label={t("saving")} />;
 
+  const isGated = action.kind !== "hidden" && !!action.disabled && !action.loading;
+  const isLoading = action.kind !== "hidden" && !!action.loading;
+  const gatedClass = isGated && "opacity-50 hover:bg-page-accent";
+
   return (
-    <div className="hidden items-center justify-end gap-2 lg:flex">
+    <div className="flex items-center justify-end gap-2">
       {onBack && (
-        <Button variant="ghost" size="sm" onClick={onBack} className="cursor-pointer gap-1.5">
+        <Button variant="outline" size="sm" onClick={onBack} className="w-44 cursor-pointer gap-1.5">
           <ArrowLeft className="size-4" />
           <span>{t("back")}</span>
         </Button>
       )}
       {onSaveDraft && (
-        <Button variant="outline" size="sm" onClick={onSaveDraft} className="min-w-32 cursor-pointer gap-1.5 px-5">
+        <Button variant="outline" size="sm" onClick={onSaveDraft} className="w-44 cursor-pointer gap-1.5">
           <CloudUpload className="size-3.5" />
           <span>{t("saveDraft")}</span>
         </Button>
@@ -46,10 +50,11 @@ export function PickemsHeaderActions({ onBack, onSaveDraft, action }: Props) {
         <Button
           size="sm"
           onClick={action.onClick}
-          disabled={action.disabled || action.loading}
-          className="min-w-28 cursor-pointer gap-1.5 bg-page-accent px-5 text-white hover:bg-page-accent/90"
+          aria-disabled={isGated}
+          disabled={isLoading}
+          className={cn("w-44 cursor-pointer gap-1.5 bg-page-accent text-white hover:bg-page-accent/90", gatedClass)}
         >
-          {action.loading ? (
+          {isLoading ? (
             spinner
           ) : (
             <>
@@ -63,10 +68,11 @@ export function PickemsHeaderActions({ onBack, onSaveDraft, action }: Props) {
         <Button
           size="sm"
           onClick={action.onClick}
-          disabled={action.disabled || action.loading}
-          className="min-w-32 cursor-pointer bg-page-accent px-5 text-white hover:bg-page-accent/90"
+          aria-disabled={isGated}
+          disabled={isLoading}
+          className={cn("w-44 cursor-pointer bg-page-accent text-white hover:bg-page-accent/90", gatedClass)}
         >
-          {action.loading ? spinner : (action.label ?? t("continue"))}
+          {isLoading ? spinner : (action.label ?? t("continue"))}
         </Button>
       )}
     </div>

--- a/src/features/pickems/components/PickemsHeaderProgress.tsx
+++ b/src/features/pickems/components/PickemsHeaderProgress.tsx
@@ -1,29 +1,43 @@
 "use client";
 
-import { Progress } from "@/shared/components/ui/progress";
+import { CheckCircle2 } from "lucide-react";
+
 import { cn } from "@/shared/lib/utils";
 
 type Props = {
   completed: number;
   total: number;
   label: string;
+  helperText?: string;
+  helperTone?: "ready";
   className?: string;
 };
 
 /**
  * Right-rail status block rendered under the action buttons in the desktop
- * header. Same shape across all three steps so the eye lands in the same place
- * regardless of which step is active: a `count / total` label, then the bar.
- *
- * Desktop-only — mobile relies on the per-screen counters inside each step
- * (group cards, "X / 8 selected" line, per-stage CTA helper text).
+ * header. Fills the rail width so the bar lines up edge-to-edge with the
+ * buttons above it. Shows the same helper text the mobile CTA bar surfaces, so
+ * the prereq state ("All set", "5 of 12 locked", etc.) reads at a glance on
+ * both layouts.
  */
-export function PickemsHeaderProgress({ completed, total, label, className }: Props) {
+export function PickemsHeaderProgress({ completed, total, label, helperText, helperTone, className }: Props) {
   const percent = total > 0 ? Math.min(100, (completed / total) * 100) : 0;
   return (
-    <div className={cn("hidden flex-col items-end gap-1 lg:flex", className)}>
-      <p className="text-sm font-medium text-foreground tabular-nums">{label}</p>
-      <Progress value={percent} className="h-1.5 w-44 *:data-[slot=progress-indicator]:bg-page-accent" />
+    <div className={cn("flex flex-col items-stretch gap-1.5", className)}>
+      <div className="flex items-center justify-between gap-3">
+        {helperText ? (
+          <p className={cn("flex min-w-0 items-center gap-1.5 text-xs font-medium", helperTone === "ready" ? "text-page-accent-strong" : "text-muted-foreground")}>
+            {helperTone === "ready" && <CheckCircle2 className="size-3.5 shrink-0" aria-hidden />}
+            <span className="truncate">{helperText}</span>
+          </p>
+        ) : (
+          <span />
+        )}
+        <p className="shrink-0 text-sm font-medium text-foreground tabular-nums">{label}</p>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div className="h-full bg-page-accent transition-all" style={{ width: `${percent}%` }} />
+      </div>
     </div>
   );
 }

--- a/src/features/pickems/components/PickemsSkeleton.tsx
+++ b/src/features/pickems/components/PickemsSkeleton.tsx
@@ -29,21 +29,26 @@ export function PickemsSkeleton({ step = "groups" }: Props = {}) {
 }
 
 function PageHeaderSkeleton() {
+  // Mirrors the live desktop rail: two same-width buttons over a helper line /
+  // count / bar. Every step uses w-44 sm-height buttons so the skeleton stays
+  // identical regardless of which step is loading.
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0 flex-1 space-y-2">
-        <Skeleton className="h-3 w-32" />
         <Skeleton className="h-8 w-72 sm:h-9 sm:w-80" />
         <Skeleton className="h-4 w-full max-w-2xl" />
       </div>
-      <div className="hidden flex-col items-end gap-3 lg:flex">
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-9 w-32 rounded-md" />
-          <Skeleton className="h-9 w-28 rounded-md" />
+      <div className="hidden flex-col items-stretch gap-2.5 lg:flex">
+        <div className="flex items-center justify-end gap-2">
+          <Skeleton className="h-8 w-44 rounded-md" />
+          <Skeleton className="h-8 w-44 rounded-md" />
         </div>
-        <div className="flex flex-col items-end gap-1">
-          <Skeleton className="h-4 w-12" />
-          <Skeleton className="h-1.5 w-44 rounded-full" />
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between gap-3">
+            <Skeleton className="h-3 w-40" />
+            <Skeleton className="h-4 w-12" />
+          </div>
+          <Skeleton className="h-1.5 w-full rounded-full" />
         </div>
       </div>
     </div>
@@ -245,10 +250,22 @@ function BracketChampionSkeleton() {
 
 function TipsCardSkeleton() {
   return (
-    <div className="flex items-start gap-2.5 rounded-xl border border-border bg-card px-3 py-3 lg:hidden">
-      <Skeleton className="mt-0.5 size-4 shrink-0 rounded-sm" />
-      <Skeleton className="mt-0.5 h-3 w-10 shrink-0" />
-      <Skeleton className="mt-0.5 h-3 max-w-md flex-1" />
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+      <TipCardSkeleton />
+      <TipCardSkeleton />
+    </div>
+  );
+}
+
+function TipCardSkeleton() {
+  return (
+    <div className="flex items-start gap-2.5 rounded-xl border border-border bg-card px-3 py-3">
+      <Skeleton className="mt-0.5 size-5 shrink-0 rounded-sm" />
+      <div className="min-w-0 flex-1 space-y-1.5 pt-1">
+        <Skeleton className="h-3.5 w-full max-w-xs" />
+        <Skeleton className="h-3.5 w-3/4 max-w-[12rem]" />
+      </div>
+      <Skeleton className="size-6 shrink-0 rounded-md" />
     </div>
   );
 }

--- a/src/features/pickems/components/PickemsTipsBanner.tsx
+++ b/src/features/pickems/components/PickemsTipsBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { GripVertical, Lightbulb, Lock, X } from "lucide-react";
+import { GripVertical, Lightbulb, Lock, LockOpen, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { cn } from "@/shared/lib/utils";
@@ -21,9 +21,10 @@ export function PickemsTipsBanner({ className }: Props) {
     <div className={cn("grid grid-cols-1 gap-3 lg:grid-cols-2", className)}>
       {!dragDismissed && (
         <Tip
-          icon={<Lightbulb className="mt-0.5 size-4 shrink-0 text-amber-500" aria-hidden />}
+          tone="amber"
+          icon={<Lightbulb className="mt-0.5 size-5 shrink-0 text-amber-500" strokeWidth={2.25} aria-hidden />}
           body={t.rich("tipsBody", {
-            handle: () => <GripVertical className="inline size-3.5 align-text-bottom text-foreground" strokeWidth={2.5} aria-hidden />,
+            handle: () => <GripVertical className="inline size-4 align-text-bottom text-foreground" strokeWidth={2.5} aria-hidden />,
           })}
           dismissLabel={t("tipsDismiss")}
           onDismiss={() => setDragDismissed(true)}
@@ -31,9 +32,10 @@ export function PickemsTipsBanner({ className }: Props) {
       )}
       {!lockDismissed && (
         <Tip
-          icon={<Lock className="mt-0.5 size-4 shrink-0 text-page-accent-strong" aria-hidden />}
+          tone="accent"
+          icon={<Lock className="mt-0.5 size-5 shrink-0 text-page-accent-strong" strokeWidth={2.25} aria-hidden />}
           body={t.rich("tipsLockBody", {
-            lockIcon: () => <Lock className="inline size-3.5 align-text-bottom text-foreground" strokeWidth={2.5} aria-hidden />,
+            lockIcon: () => <LockOpen className="inline size-4 align-text-bottom text-foreground" strokeWidth={2.5} aria-hidden />,
           })}
           dismissLabel={t("tipsDismiss")}
           onDismiss={() => setLockDismissed(true)}
@@ -43,11 +45,31 @@ export function PickemsTipsBanner({ className }: Props) {
   );
 }
 
-function Tip({ icon, body, dismissLabel, onDismiss }: { icon: React.ReactNode; body: React.ReactNode; dismissLabel: string; onDismiss: () => void }) {
+type TipTone = "amber" | "accent";
+
+function Tip({
+  tone,
+  icon,
+  body,
+  dismissLabel,
+  onDismiss,
+}: {
+  tone: TipTone;
+  icon: React.ReactNode;
+  body: React.ReactNode;
+  dismissLabel: string;
+  onDismiss: () => void;
+}) {
   return (
-    <div className="flex items-start gap-2.5 rounded-xl border border-border bg-card px-3 py-3">
+    <div
+      className={cn(
+        "flex items-start gap-2.5 rounded-xl border px-3 py-3",
+        tone === "amber" && "border-amber-300/70 bg-amber-100/80 dark:border-amber-500/30 dark:bg-amber-500/15",
+        tone === "accent" && "border-page-accent/20 bg-page-accent-soft"
+      )}
+    >
       {icon}
-      <span className="min-w-0 flex-1 text-xs leading-relaxed text-muted-foreground">{body}</span>
+      <span className="min-w-0 flex-1 text-sm leading-snug text-foreground/85">{body}</span>
       <button
         type="button"
         onClick={onDismiss}

--- a/src/features/pickems/components/PickemsView.tsx
+++ b/src/features/pickems/components/PickemsView.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 import { useHydrated } from "@/shared/hooks/useHydrated";
 
@@ -12,7 +14,7 @@ import { useStep } from "../hooks/useStep";
 import { readBestThirdsDraft } from "../lib/bestThirdsDraftStorage";
 import { readGroupsDraft } from "../lib/groupsDraftStorage";
 import { stepIndex } from "../lib/pickemStep";
-import { projectBracket } from "../lib/projectBracket";
+import { projectBracket, pruneBracketDraft } from "../lib/projectBracket";
 import type { BracketDraft, PickemProgress, PickemStep, UserPickem } from "../types/pickems.types";
 
 import { PickemsLockedBanner } from "./PickemsLockedBanner";
@@ -32,9 +34,10 @@ const EMPTY_BRACKET_DRAFT: BracketDraft = {};
 
 export function PickemsView({ initialData, userId }: Props) {
   const hydrated = useHydrated();
+  const tToasts = useTranslations("pickems.toasts");
   const { data = initialData } = usePickems(initialData);
   const [step, rawSetStep] = useStep();
-  const { draft: bracketDraft } = useBracketDraft(userId);
+  const { draft: bracketDraft, replaceDraft: replaceBracketDraft, isHydrated: bracketDraftHydrated } = useBracketDraft(userId);
   const groupsSave = useSaveGroups(userId);
   const bestThirdsSave = useSaveBestThirds(userId);
   const [navigating, setNavigating] = useState(false);
@@ -42,6 +45,20 @@ export function PickemsView({ initialData, userId }: Props) {
   // When the pickem is locked the server is read-only; localStorage drafts can
   // never sync, so ignore them and project against the server-saved state only
   const effectiveBracketDraft = data.is_locked ? EMPTY_BRACKET_DRAFT : bracketDraft;
+
+  // Cross-device drift: another browser may have changed group order or best
+  // thirds, which on the server cascades into the R32 home/away pairings. The
+  // local draft on *this* device can still hold picks for teams that no longer
+  // belong in those slots. Walk the projected bracket and drop the now-invalid
+  // entries — otherwise the stepper count, the per-stage tabs and the saved
+  // picks all disagree (e.g. R32 shows 15/16 yet QF onward read as complete).
+  useEffect(() => {
+    if (!bracketDraftHydrated || data.is_locked) return;
+    const { pruned, removedCount } = pruneBracketDraft(data.bracket, bracketDraft);
+    if (removedCount === 0) return;
+    replaceBracketDraft(pruned);
+    toast.warning(tToasts("picksClearedByGroupChange", { n: removedCount }));
+  }, [bracketDraftHydrated, data.is_locked, data.bracket, bracketDraft, replaceBracketDraft, tToasts]);
 
   // Progress counts derived from the *local* cache state (or pure server state
   // when locked). The stepper sub-line and the navigability gate both read
@@ -143,7 +160,9 @@ export function PickemsView({ initialData, userId }: Props) {
           onSaveDraft={groupsSave.saveDraft}
           onContinue={async () => {
             try {
-              await groupsSave.saveAndAwait();
+              if (readGroupsDraft(userId)) {
+                await groupsSave.saveAndAwait();
+              }
               rawSetStep("thirds");
             } catch {
               // Toast already surfaced.
@@ -162,7 +181,9 @@ export function PickemsView({ initialData, userId }: Props) {
           onToggle={bestThirdsSave.toggle}
           onContinue={async () => {
             try {
-              await bestThirdsSave.saveAndAwait();
+              if (readBestThirdsDraft(userId)) {
+                await bestThirdsSave.saveAndAwait();
+              }
               rawSetStep("bracket");
             } catch {
               // Toast already surfaced

--- a/src/features/pickems/components/StepBestThirds.tsx
+++ b/src/features/pickems/components/StepBestThirds.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 import type { Team } from "@/shared/types/wcp.types";
 
@@ -43,9 +44,16 @@ export function StepBestThirds({ data, step, onStep, progress, canNavigateTo, on
   const count = selectedCodes.size;
   const isReady = count === BEST_THIRDS_REQUIRED;
 
-  const helperText = !isReady ? t("bestThirds.moreNeeded", { n: BEST_THIRDS_REQUIRED - count }) : undefined;
+  const helperText = isReady ? t("common.readyForStep3") : t("bestThirds.moreNeeded", { n: BEST_THIRDS_REQUIRED - count });
   const prev = prevStep("thirds");
   const backFn = !data.is_locked && prev ? () => onStep(prev) : undefined;
+  const handleContinue = () => {
+    if (!isReady) {
+      toast(t("toasts.selectAllThirdsFirst"));
+      return;
+    }
+    onContinue();
+  };
   const action: CTAAction = data.is_locked
     ? { kind: "hidden" }
     : {
@@ -54,7 +62,8 @@ export function StepBestThirds({ data, step, onStep, progress, canNavigateTo, on
         disabled: !isReady,
         loading: isSaving,
         helperText,
-        onClick: onContinue,
+        helperTone: isReady ? "ready" : undefined,
+        onClick: handleContinue,
       };
 
   return (
@@ -62,10 +71,16 @@ export function StepBestThirds({ data, step, onStep, progress, canNavigateTo, on
       <PickemsHeader
         step="thirds"
         rightSlot={
-          <>
+          <div className="hidden flex-col items-stretch gap-2.5 lg:flex">
             <PickemsHeaderActions action={action} onBack={backFn} />
-            <PickemsHeaderProgress completed={count} total={BEST_THIRDS_REQUIRED} label={`${count} / ${BEST_THIRDS_REQUIRED}`} />
-          </>
+            <PickemsHeaderProgress
+              completed={count}
+              total={BEST_THIRDS_REQUIRED}
+              label={`${count} / ${BEST_THIRDS_REQUIRED}`}
+              helperText={data.is_locked ? undefined : helperText}
+              helperTone={isReady ? "ready" : undefined}
+            />
+          </div>
         }
       />
 
@@ -81,7 +96,7 @@ export function StepBestThirds({ data, step, onStep, progress, canNavigateTo, on
         </div>
       </div>
 
-      <PickemsCTABar action={action} onBack={backFn} />
+      <PickemsCTABar action={action} onBack={backFn} progress={{ completed: count, total: BEST_THIRDS_REQUIRED }} />
     </section>
   );
 }

--- a/src/features/pickems/components/StepBracket.tsx
+++ b/src/features/pickems/components/StepBracket.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 import { useBracketDraft } from "../hooks/useBracketDraft";
 import { useSubmitBracket } from "../hooks/useSubmitBracket";
@@ -33,11 +34,20 @@ type Props = {
 export function StepBracket({ data, step, onStep, progress, canNavigateTo, userId }: Props) {
   const t = useTranslations("pickems.bracket");
   const tRounds = useTranslations("pickems.bracket.rounds");
+  const tCommon = useTranslations("pickems.common");
+  const tToasts = useTranslations("pickems.toasts");
   const { draft: rawDraft, pick } = useBracketDraft(userId);
   const { submit, isSubmitting } = useSubmitBracket();
   // Active stage is owned here so the mobile CTA bar can react to it (per-stage
   // counter, "Next: <round>" button). BracketMobile reads + writes through props.
   const [activeStage, setActiveStage] = useState<BracketStageCode>("round_of_32");
+
+  const goToStage = (stage: BracketStageCode) => {
+    setActiveStage(stage);
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
 
   // When locked, ignore the local draft — only show what the user committed.
   const draft = data.is_locked ? EMPTY_DRAFT : rawDraft;
@@ -60,13 +70,13 @@ export function StepBracket({ data, step, onStep, progress, canNavigateTo, userI
   const prevStage = stageIdx > 0 ? STAGES[stageIdx - 1] : null;
 
   const prev = prevStep("bracket");
-  const helperText = !isReady ? t("picksLeft", { n: TOTAL_BRACKET_PICKS - pickedCount }) : undefined;
+  const helperText = isReady ? tCommon("readyToSubmit") : t("picksLeft", { n: TOTAL_BRACKET_PICKS - pickedCount });
   const desktopBack = !data.is_locked && prev ? () => onStep(prev) : undefined;
   // Mobile back walks the tabs leftward; once we're at R32, it falls through to
   // the step-level back (→ best thirds). Keeps the gesture meaning "previous"
   // whether that's a previous round or the previous step. When locked, we drop
   // the Back affordance entirely — the stepper is the only navigation.
-  const mobileBack = data.is_locked ? undefined : prevStage ? () => setActiveStage(prevStage) : desktopBack;
+  const mobileBack = data.is_locked ? undefined : prevStage ? () => goToStage(prevStage) : desktopBack;
 
   const desktopAction: CTAAction = data.is_locked
     ? { kind: "hidden" }
@@ -76,6 +86,7 @@ export function StepBracket({ data, step, onStep, progress, canNavigateTo, userI
         disabled: !isReady,
         loading: isSubmitting,
         helperText,
+        helperTone: isReady ? "ready" : undefined,
         onClick: () => submit(draft),
       };
 
@@ -90,8 +101,15 @@ export function StepBracket({ data, step, onStep, progress, canNavigateTo, userI
           kind: "continue",
           label: tRounds(nextStage),
           disabled: !stageStats.isComplete,
-          helperText: stageStats.isComplete ? undefined : t("roundLeft", { n: stageStats.remaining }),
-          onClick: () => setActiveStage(nextStage),
+          helperText: stageStats.isComplete ? tCommon("readyForRound", { round: tRounds(nextStage) }) : t("roundLeft", { n: stageStats.remaining }),
+          helperTone: stageStats.isComplete ? "ready" : undefined,
+          onClick: () => {
+            if (!stageStats.isComplete) {
+              toast(tToasts("finishRoundFirst"));
+              return;
+            }
+            goToStage(nextStage);
+          },
         }
       : {
           kind: "submit",
@@ -99,14 +117,21 @@ export function StepBracket({ data, step, onStep, progress, canNavigateTo, userI
           disabled: !isReady,
           loading: isSubmitting,
           helperText,
+          helperTone: isReady ? "ready" : undefined,
           onClick: () => submit(draft),
         };
 
   const rightSlot = (
-    <>
+    <div className="hidden flex-col items-stretch gap-2.5 lg:flex">
       <PickemsHeaderActions action={desktopAction} onBack={desktopBack} />
-      <PickemsHeaderProgress completed={pickedCount} total={TOTAL_BRACKET_PICKS} label={`${pickedCount} / ${TOTAL_BRACKET_PICKS}`} />
-    </>
+      <PickemsHeaderProgress
+        completed={pickedCount}
+        total={TOTAL_BRACKET_PICKS}
+        label={`${pickedCount} / ${TOTAL_BRACKET_PICKS}`}
+        helperText={data.is_locked ? undefined : helperText}
+        helperTone={isReady ? "ready" : undefined}
+      />
+    </div>
   );
 
   return (
@@ -116,9 +141,13 @@ export function StepBracket({ data, step, onStep, progress, canNavigateTo, userI
       <PickemsStepper current={step} progress={progress} onChange={onStep} canNavigateTo={canNavigateTo} />
 
       <BracketDesktop bracket={projected} champion={champion} disabled={data.is_locked} onPick={pick} />
-      <BracketMobile bracket={projected} champion={champion} disabled={data.is_locked} onPick={pick} activeStage={activeStage} onStageChange={setActiveStage} />
+      <BracketMobile bracket={projected} champion={champion} disabled={data.is_locked} onPick={pick} activeStage={activeStage} onStageChange={goToStage} />
 
-      <PickemsCTABar action={mobileAction} onBack={mobileBack} />
+      <PickemsCTABar
+        action={mobileAction}
+        onBack={mobileBack}
+        progress={nextStage ? { completed: stageStats.completed, total: stageStats.total } : { completed: pickedCount, total: TOTAL_BRACKET_PICKS }}
+      />
     </section>
   );
 }

--- a/src/features/pickems/components/StepGroups.tsx
+++ b/src/features/pickems/components/StepGroups.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ArrowDownUp } from "lucide-react";
+import { ChevronsUpDown } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 import { Button } from "@/shared/components/ui/button";
 import type { GroupCode } from "@/shared/types/wcp.types";
@@ -57,9 +58,25 @@ export function StepGroups({ data, step, onStep, progress, canNavigateTo, onReor
   };
 
   const allLocked = progress.groups.completed === progress.groups.total;
+  const helperText = allLocked ? t("common.readyForStep2") : t("groups.lockedCount", { completed: progress.groups.completed, total: progress.groups.total });
+  const handleContinue = () => {
+    if (!allLocked) {
+      toast(t("toasts.lockAllGroupsFirst"));
+      return;
+    }
+    onContinue();
+  };
   const action: CTAAction = data.is_locked
     ? { kind: "hidden" }
-    : { kind: "continue", label: t("common.continueToStep2"), loading: isSaving, onClick: onContinue, disabled: !allLocked };
+    : {
+        kind: "continue",
+        label: t("common.continueToStep2"),
+        loading: isSaving,
+        disabled: !allLocked,
+        onClick: handleContinue,
+        helperText,
+        helperTone: allLocked ? "ready" : undefined,
+      };
   const saveDraftFn = data.is_locked ? undefined : onSaveDraft;
 
   return (
@@ -67,14 +84,16 @@ export function StepGroups({ data, step, onStep, progress, canNavigateTo, onReor
       <PickemsHeader
         step="groups"
         rightSlot={
-          <>
+          <div className="hidden flex-col items-stretch gap-2.5 lg:flex">
             <PickemsHeaderActions action={action} onSaveDraft={saveDraftFn} />
             <PickemsHeaderProgress
               completed={progress.groups.completed}
               total={progress.groups.total}
               label={`${progress.groups.completed} / ${progress.groups.total}`}
+              helperText={data.is_locked ? undefined : helperText}
+              helperTone={allLocked ? "ready" : undefined}
             />
-          </>
+          </div>
         }
       />
 
@@ -85,7 +104,7 @@ export function StepGroups({ data, step, onStep, progress, canNavigateTo, onReor
       <div className="flex items-center justify-between pt-1 md:hidden">
         <h3 className="text-xl font-semibold tracking-tight text-foreground">{t("groups.sectionLabel")}</h3>
         <Button variant="outline" size="sm" onClick={toggleAll} className="min-w-32 cursor-pointer gap-1.5">
-          <ArrowDownUp className="size-3.5" aria-hidden />
+          <ChevronsUpDown className="size-3.5" aria-hidden />
           {allOpen ? t("groups.collapseAll") : t("groups.expandAll")}
         </Button>
       </div>
@@ -105,7 +124,7 @@ export function StepGroups({ data, step, onStep, progress, canNavigateTo, onReor
         ))}
       </div>
 
-      <PickemsCTABar action={action} onSaveDraft={saveDraftFn} />
+      <PickemsCTABar action={action} onSaveDraft={saveDraftFn} progress={progress.groups} />
     </section>
   );
 }

--- a/src/features/pickems/hooks/useBracketDraft.ts
+++ b/src/features/pickems/hooks/useBracketDraft.ts
@@ -17,11 +17,14 @@ export function useBracketDraft(userId: string | undefined) {
   const hydrate = useBracketDraftStore((s) => s.hydrate);
   const pick = useBracketDraftStore((s) => s.pick);
   const clearPick = useBracketDraftStore((s) => s.clearPick);
+  const replaceDraft = useBracketDraftStore((s) => s.replaceDraft);
   const reset = useBracketDraftStore((s) => s.reset);
 
   useIsomorphicLayoutEffect(() => {
     if (storedUserId !== userId) hydrate(userId);
   }, [storedUserId, userId, hydrate]);
 
-  return { draft, pick, clearPick, reset };
+  const isHydrated = storedUserId === userId;
+
+  return { draft, pick, clearPick, replaceDraft, reset, isHydrated };
 }

--- a/src/features/pickems/lib/projectBracket.ts
+++ b/src/features/pickems/lib/projectBracket.ts
@@ -80,3 +80,28 @@ export function projectBracket(serverBracket: BracketMatchSlot[], draft: Bracket
 export function findChampion(bracket: BracketMatchSlot[]): Team | null {
   return bracket.find((slot) => slot.stage_code === "final")?.picked_team ?? null;
 }
+
+/**
+ * Walks the projected bracket and drops any draft picks that no longer
+ * resolve — i.e. the picked team is no longer in the slot's home/away after
+ * projecting against the current server bracket. This happens when group order
+ * or best-thirds were changed on another device, causing the server to
+ * recompute R32 home/away while this device's localStorage still holds the
+ * old picks. Returns the cleaned draft and how many entries were dropped, so
+ * callers can surface a toast.
+ */
+export function pruneBracketDraft(serverBracket: BracketMatchSlot[], draft: BracketDraft): { pruned: BracketDraft; removedCount: number } {
+  const projected = projectBracket(serverBracket, draft);
+  const pruned: BracketDraft = {};
+  let removedCount = 0;
+  for (const slot of projected) {
+    const draftCode = draft[slot.match_id];
+    if (draftCode === undefined) continue;
+    if (slot.picked_team?.fifa_code === draftCode) {
+      pruned[slot.match_id] = draftCode;
+    } else {
+      removedCount++;
+    }
+  }
+  return { pruned, removedCount };
+}

--- a/src/features/pickems/store/bracketDraft.store.ts
+++ b/src/features/pickems/store/bracketDraft.store.ts
@@ -9,6 +9,7 @@ type BracketDraftStore = {
   hydrate: (userId: string | undefined) => void;
   pick: (matchId: number, fifaCode: string) => void;
   clearPick: (matchId: number) => void;
+  replaceDraft: (draft: BracketDraft) => void;
   reset: () => void;
 };
 
@@ -35,6 +36,10 @@ export const useBracketDraftStore = create<BracketDraftStore>((set, get) => ({
     delete next[matchId];
     writeBracketDraft(get().userId, next);
     set({ draft: next });
+  },
+  replaceDraft: (draft) => {
+    writeBracketDraft(get().userId, draft);
+    set({ draft });
   },
   reset: () => {
     clearBracketDraft(get().userId);


### PR DESCRIPTION
## Related issue

Closes #33

## What changed

- CTA bar gains a "ready to continue" state (checkmark + accent text) and a mobile progress bar; gated buttons stay clickable and surface a toast instead of going inert
- Mobile CTA bar measures its own height into `--pickems-cta-height` so the global footer and sonner toasts no longer overlap it (`src/app/pickems/layout.tsx`)
- Bracket stage navigation smooth-scrolls to top, and switching rounds shows per-stage progress in the CTA bar
- Prune local bracket draft when server group/thirds order changes on another device, with a toast for dropped picks (`src/features/pickems/lib/projectBracket.ts`)
- Skip the save round-trip on step continue when no local draft exists
- i18n: new "ready" helper strings, group-locked count, and gated-action toasts in `en`/`es`

## How to test

- [ ] Open `/pickems` on mobile width: scroll to bottom and confirm the footer sits flush above the CTA bar with no gap, and toasts appear above it
- [ ] On step 1, tap Continue before locking all 12 groups — expect a toast, not a dead button; lock all 12 and the helper flips to "All set, continue to step 2" with a check
- [ ] On step 2, repeat with fewer than 8 thirds selected, then complete the 8
- [ ] On step 3 mobile, complete R32 → tap the round CTA and confirm it scrolls to top of the next stage; progress bar resets per stage
- [ ] In one browser, change group order or best-thirds; reload the bracket step in another browser and confirm a warning toast drops the now-invalid picks
- [ ] Switch locale to `es` and verify the new strings read naturally