### PR TITLE
fix: unify board dialog width and i18n match card group label

### DIFF
--- a/src/features/boards/components/CreateBoardDialog.tsx
+++ b/src/features/boards/components/CreateBoardDialog.tsx
@@ -13,6 +13,7 @@ import { useAutoFocusUnlessMobile } from "@/shared/hooks/useAutoFocusUnlessMobil
 import { translateApiError } from "@/shared/lib/api/errors";
 
 import { useCreateBoard } from "../hooks/useBoardMutations";
+import { BOARD_DIALOG_WIDTH } from "../lib/boardDialog";
 import { rememberLastBoard } from "../lib/lastBoardCookie";
 
 type Props = {
@@ -65,7 +66,7 @@ export function CreateBoardDialog({ open, onOpenChange }: Props) {
         onOpenChange(next);
       }}
     >
-      <DialogContent onOpenAutoFocus={focus.onOpenAutoFocus}>
+      <DialogContent onOpenAutoFocus={focus.onOpenAutoFocus} className={BOARD_DIALOG_WIDTH}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>
           <DialogDescription>{t("description")}</DialogDescription>
@@ -88,10 +89,10 @@ export function CreateBoardDialog({ open, onOpenChange }: Props) {
             </FieldDescription>
           </Field>
           <DialogFooter className="flex-col sm:flex-row-reverse sm:justify-start">
-            <Button type="submit" disabled={!isValid || isPending} className="bg-page-accent text-white hover:bg-page-accent/90">
+            <Button type="submit" disabled={!isValid || isPending} className="bg-page-accent text-white hover:bg-page-accent/90 sm:min-w-24 sm:px-6">
               {t("submit")}
             </Button>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending} className="sm:min-w-24 sm:px-6">
               {t("cancel")}
             </Button>
           </DialogFooter>

--- a/src/features/boards/components/InviteDialog.tsx
+++ b/src/features/boards/components/InviteDialog.tsx
@@ -7,6 +7,7 @@ import { CopyButton } from "@/shared/components/CopyButton";
 import { Button } from "@/shared/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
 
+import { BOARD_DIALOG_WIDTH } from "../lib/boardDialog";
 import type { Board } from "../types/boards.types";
 
 type Props = {
@@ -20,7 +21,7 @@ export function InviteDialog({ board, open, onOpenChange }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className={BOARD_DIALOG_WIDTH}>
         <DialogHeader>
           <DialogTitle>{t("title", { name: board.name })}</DialogTitle>
           <DialogDescription>{t("description")}</DialogDescription>

--- a/src/features/boards/components/JoinBoardDialog.tsx
+++ b/src/features/boards/components/JoinBoardDialog.tsx
@@ -13,6 +13,7 @@ import { useAutoFocusUnlessMobile } from "@/shared/hooks/useAutoFocusUnlessMobil
 import { translateApiError } from "@/shared/lib/api/errors";
 
 import { useJoinBoard } from "../hooks/useBoardMutations";
+import { BOARD_DIALOG_WIDTH } from "../lib/boardDialog";
 import { rememberLastBoard } from "../lib/lastBoardCookie";
 
 type Props = {
@@ -71,7 +72,7 @@ export function JoinBoardDialog({ open, onOpenChange }: Props) {
         onOpenChange(next);
       }}
     >
-      <DialogContent onOpenAutoFocus={focus.onOpenAutoFocus}>
+      <DialogContent onOpenAutoFocus={focus.onOpenAutoFocus} className={BOARD_DIALOG_WIDTH}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>
           <DialogDescription>{t("description")}</DialogDescription>
@@ -101,10 +102,10 @@ export function JoinBoardDialog({ open, onOpenChange }: Props) {
             </div>
           </Field>
           <DialogFooter className="w-full flex-col sm:flex-row-reverse sm:justify-start">
-            <Button type="submit" disabled={!isValid || isPending} className="bg-page-accent text-white hover:bg-page-accent/90">
+            <Button type="submit" disabled={!isValid || isPending} className="bg-page-accent text-white hover:bg-page-accent/90 sm:min-w-24 sm:px-6">
               {t("submit")}
             </Button>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending} className="sm:min-w-24 sm:px-6">
               {t("cancel")}
             </Button>
           </DialogFooter>

--- a/src/features/boards/components/LeaveBoardDialog.tsx
+++ b/src/features/boards/components/LeaveBoardDialog.tsx
@@ -9,6 +9,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { translateApiError } from "@/shared/lib/api/errors";
 
 import { useLeaveBoard } from "../hooks/useBoardMutations";
+import { BOARD_DIALOG_WIDTH } from "../lib/boardDialog";
 import type { Board } from "../types/boards.types";
 
 type Props = {
@@ -37,16 +38,16 @@ export function LeaveBoardDialog({ board, open, onOpenChange }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className={BOARD_DIALOG_WIDTH}>
         <DialogHeader>
           <DialogTitle>{t("leave.confirm")}</DialogTitle>
           <DialogDescription>{t("leave.description")}</DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={leave.isPending}>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={leave.isPending} className="sm:min-w-24 sm:px-6">
             {t("cancel")}
           </Button>
-          <Button variant="destructive" onClick={handleLeave} disabled={leave.isPending}>
+          <Button variant="destructive" onClick={handleLeave} disabled={leave.isPending} className="sm:min-w-24 sm:px-6">
             {t("leave.cta")}
           </Button>
         </DialogFooter>

--- a/src/features/boards/components/ManageBoardGeneral.tsx
+++ b/src/features/boards/components/ManageBoardGeneral.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/shared/lib/utils";
 
 import { useBoardActionError } from "../hooks/useBoardActionError";
 import { useDeleteBoard, useRegenerateJoinCode, useRenameBoard } from "../hooks/useBoardMutations";
+import { BOARD_DIALOG_WIDTH } from "../lib/boardDialog";
 import { canDeleteBoard, canManageBoard, isGlobalBoard } from "../lib/boardRole";
 import type { Board } from "../types/boards.types";
 
@@ -135,16 +136,16 @@ export function ManageBoardGeneral({ board, onClose, onPermissionLost }: Props) 
       ) : null}
 
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <DialogContent>
+        <DialogContent className={BOARD_DIALOG_WIDTH}>
           <DialogHeader>
             <DialogTitle>{t("regenerateConfirm")}</DialogTitle>
             <DialogDescription>{t("regenerateWarning")}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)} className="sm:min-w-24 sm:px-6">
               {t("cancel")}
             </Button>
-            <Button onClick={handleRegenerate} disabled={regenerate.isPending} className="bg-page-accent text-white hover:bg-page-accent/90">
+            <Button onClick={handleRegenerate} disabled={regenerate.isPending} className="bg-page-accent text-white hover:bg-page-accent/90 sm:min-w-24 sm:px-6">
               {t("regenerate")}
             </Button>
           </DialogFooter>
@@ -158,17 +159,17 @@ export function ManageBoardGeneral({ board, onClose, onPermissionLost }: Props) 
           setConfirmDelete(next);
         }}
       >
-        <DialogContent onOpenAutoFocus={deleteFocus.onOpenAutoFocus}>
+        <DialogContent onOpenAutoFocus={deleteFocus.onOpenAutoFocus} className={BOARD_DIALOG_WIDTH}>
           <DialogHeader>
             <DialogTitle>{t("delete.confirm", { name: board.name })}</DialogTitle>
             <DialogDescription>{t("delete.confirmDescription")}</DialogDescription>
           </DialogHeader>
           <Input value={deleteTyped} onChange={(event) => setDeleteTyped(event.target.value)} autoFocus={deleteFocus.autoFocus} />
           <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmDelete(false)}>
+            <Button variant="outline" onClick={() => setConfirmDelete(false)} className="sm:min-w-24 sm:px-6">
               {t("delete.cancel")}
             </Button>
-            <Button variant="destructive" disabled={deleteTyped !== board.name || remove.isPending} onClick={handleDelete}>
+            <Button variant="destructive" disabled={deleteTyped !== board.name || remove.isPending} onClick={handleDelete} className="sm:min-w-24 sm:px-6">
               {t("delete.cta")}
             </Button>
           </DialogFooter>

--- a/src/features/boards/components/ManageBoardMembers.tsx
+++ b/src/features/boards/components/ManageBoardMembers.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/shared/lib/utils";
 import { BOARD_MEMBERS_PAGE_SIZE } from "../api/boards";
 import { useBoardActionError } from "../hooks/useBoardActionError";
 import { useBoardMembers, useRemoveMember, useTransferOwnership, useUpdateMemberRole } from "../hooks/useBoardMembers";
+import { BOARD_DIALOG_WIDTH } from "../lib/boardDialog";
 import { canManageBoard } from "../lib/boardRole";
 import type { Board, BoardMember } from "../types/boards.types";
 
@@ -296,7 +297,7 @@ function RemoveMemberDialog({ target, onOpenChange, onSubmit, isPending }: Remov
 
   return (
     <Dialog open={Boolean(target)} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className={BOARD_DIALOG_WIDTH}>
         {target ? (
           <>
             <DialogHeader>
@@ -304,10 +305,10 @@ function RemoveMemberDialog({ target, onOpenChange, onSubmit, isPending }: Remov
               <DialogDescription>{t("description")}</DialogDescription>
             </DialogHeader>
             <DialogFooter>
-              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending} className="sm:min-w-24 sm:px-6">
                 {t("cancel")}
               </Button>
-              <Button variant="destructive" onClick={onSubmit} disabled={isPending}>
+              <Button variant="destructive" onClick={onSubmit} disabled={isPending} className="sm:min-w-24 sm:px-6">
                 {t("submit")}
               </Button>
             </DialogFooter>
@@ -341,7 +342,7 @@ function TransferOwnershipDialog({ target, onOpenChange, onSubmit, isPending }: 
         onOpenChange(next);
       }}
     >
-      <DialogContent onOpenAutoFocus={focus.onOpenAutoFocus}>
+      <DialogContent onOpenAutoFocus={focus.onOpenAutoFocus} className={BOARD_DIALOG_WIDTH}>
         {target ? (
           <>
             <DialogHeader>
@@ -350,10 +351,10 @@ function TransferOwnershipDialog({ target, onOpenChange, onSubmit, isPending }: 
             </DialogHeader>
             <Input value={typed} onChange={(event) => setTyped(event.target.value)} placeholder={t("placeholder")} autoFocus={focus.autoFocus} />
             <DialogFooter>
-              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending} className="sm:min-w-24 sm:px-6">
                 {t("cancel")}
               </Button>
-              <Button variant="destructive" onClick={onSubmit} disabled={!isValid || isPending}>
+              <Button variant="destructive" onClick={onSubmit} disabled={!isValid || isPending} className="sm:min-w-24 sm:px-6">
                 {t("submit")}
               </Button>
             </DialogFooter>

--- a/src/features/boards/lib/boardDialog.ts
+++ b/src/features/boards/lib/boardDialog.ts
@@ -1,0 +1,4 @@
+// Single width shared by every board dialog so they stay visually unified across
+// the board view. The Join dialog's 8-slot OTP needs the larger `lg` size; the
+// rest match it. Change here to resize all board dialogs at once.
+export const BOARD_DIALOG_WIDTH = "sm:max-w-lg";

--- a/src/features/schedule/components/MatchCard.tsx
+++ b/src/features/schedule/components/MatchCard.tsx
@@ -52,7 +52,7 @@ export function MatchCard({ match, isAuthed }: Props) {
   return (
     <Card data-match-id={match.id} className={cn("relative gap-3 px-4 py-4", editing && "ring-2 ring-page-accent")} size="sm">
       <header className="flex items-center justify-between text-xs text-muted-foreground">
-        <span className="font-medium uppercase tracking-wide">{stageHeaderLabel(match, stageT)}</span>
+        <span className="font-medium uppercase tracking-wide">{stageHeaderLabel(match, t, stageT)}</span>
         <KickoffTime kickoffAt={match.kickoff_at} />
       </header>
 
@@ -100,8 +100,8 @@ export function MatchCard({ match, isAuthed }: Props) {
   );
 }
 
-function stageHeaderLabel(match: Match, stageT: (key: string) => string): string {
-  if (match.stage_code === "group_stage" && match.group_code) return `Group ${match.group_code} · M${match.id}`;
+function stageHeaderLabel(match: Match, t: (key: string) => string, stageT: (key: string) => string): string {
+  if (match.stage_code === "group_stage" && match.group_code) return `${t("group")} ${match.group_code} · M${match.id}`;
   return `${stageT(match.stage_code)} · M${match.id}`;
 }
 

--- a/src/i18n/messages/schedule/en.json
+++ b/src/i18n/messages/schedule/en.json
@@ -35,6 +35,7 @@
     "done": "Done"
   },
   "card": {
+    "group": "Group",
     "yourPick": "Your pick",
     "noPickMade": "No pick made",
     "tapToPick": "Tap to pick",

--- a/src/i18n/messages/schedule/es.json
+++ b/src/i18n/messages/schedule/es.json
@@ -35,6 +35,7 @@
     "done": "Listo"
   },
   "card": {
+    "group": "Grupo",
     "yourPick": "Tu pick",
     "noPickMade": "No hiciste tu pick",
     "tapToPick": "Haz tu pick",


### PR DESCRIPTION
## What changed

- Add shared `BOARD_DIALOG_WIDTH` constant (`sm:max-w-lg`) and apply it to every board dialog (create, join, invite, leave, manage general/members) so widths match
- Give all board dialog footer buttons consistent `sm:min-w-24 sm:px-6` sizing
- i18n the match card "Group" label (hardcoded → `card.group` key) in en/es

## How to test

- [ ] Open each board dialog (Create, Join, Invite, Leave, Regenerate code, Delete, Remove member, Transfer ownership) and confirm they share the same width
- [ ] Confirm footer buttons in those dialogs are evenly sized on desktop
- [ ] View the schedule on a group-stage match and confirm the "Group" label localizes (EN/ES)