### PR TITLE
ci: add release + deploy automation (mirror api)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: release
+description: Cut a release in one command — open the develop→main PR and queue it to auto-merge as a merge commit. A maintainer's approval then triggers merge → tag → draft release automatically. Never squash develop→main.
+---
+
+# Release
+
+Promote `develop` to `main` and ship it in **one command**. You open the release PR; once a
+maintainer approves, the rest is automatic:
+
+```
+/release → PR opened + auto-merge queued → (maintainer approves)
+        → GitHub merges as a MERGE COMMIT → release.yml tags vX.Y.Z + auto-drafts the notes
+        → you publish the draft → deploy.yml ships the tag to Railway prod
+```
+
+## The one rule
+
+> **`develop → main` must merge as a MERGE COMMIT — never squash or rebase.**
+
+Squashing gives `main` a commit that doesn't have develop's tip as an ancestor, so the next
+release PR shows every develop commit and hits phantom conflicts. A merge commit keeps history
+shared. (Squashing `feat/* → develop` is fine — those branches are short-lived; see `open-pr`.)
+The `--auto --merge` in step 6 enforces this.
+
+## How it's wired
+
+- **Auto-merge** merges the PR as a merge commit the instant its required review lands.
+- **`release.yml`** runs on the merged PR: reads the version from the title
+  (`chore: release vX.Y.Z`), tags main's merge commit, **auto-generates a categorized changelog**
+  from the commits, and creates the release **as a draft**. You don't hand-write release notes.
+- **`deploy.yml`** runs when you **publish** that draft: it deploys the released tag to Railway
+  production. Publishing is the single go-live gate.
+
+**Prerequisites** (already configured — check these if a release misbehaves):
+
+- `main` protection: "Require linear history" **off**; requires **1 non-author review**.
+- Repo: "Allow auto-merge" and "Allow merge commits" **on**.
+- `release.yml` triggers on `pull_request: [closed]` → `main`; `deploy.yml` on `release: [published]`.
+- Railway's native auto-deploy is **off** (deploy goes through `deploy.yml`); `RAILWAY_TOKEN` secret set.
+
+## Steps
+
+1. `git fetch origin --tags --prune`. If `git log origin/main..origin/develop --no-merges --oneline`
+   is empty → stop: "Nothing to release."
+2. If a `develop→main` PR is already open (`gh pr list --base main --head develop --state open`),
+   report its status and stop — don't open another.
+3. **Pre-flight.** `main` has no required checks, so confirm develop is green:
+   `gh run list --branch develop -L 1 --json conclusion,status`. If the latest run isn't
+   `success`, warn and ask before continuing.
+4. **Version.** Propose the next semver and have the user confirm — never guess silently:
+   - Last tag: `git tag -l 'v*.*.*' --sort=-v:refname | head -1` (no tags yet → first release is `v0.1.0`).
+   - Bump from the commits since that tag: `BREAKING CHANGE`/`type!:` → **major**; else `feat:` →
+     **minor**; else → **patch**.
+5. **Open the PR.** Title MUST be exactly `chore: release vX.Y.Z` — `release.yml` parses the
+   version from it. Body is the PR description for the reviewer (the published release notes are
+   auto-generated): terse grouped highlights (~150 words, same density as `open-pr`) from real
+   commits; skip lockfile bumps and generated files.
+   ```bash
+   gh pr create --base main --head develop --title "chore: release vX.Y.Z" --body "$(cat <<'EOF'
+   ## Release vX.Y.Z
+
+   <one-line summary>
+
+   ### Highlights
+   - <feat bullet>
+
+   ### Fixes
+   - <fix bullet, if notable>
+   EOF
+   )"
+   ```
+6. **Queue auto-merge as a merge commit:** `gh pr merge <num> --auto --merge`. If rejected with
+   "merge method merge commits are not allowed", a prerequisite drifted — fix it and re-queue.
+   Never fall back to squash or rebase.
+7. **Report and stop** — don't tag, merge, or publish; those are the automation's and the user's
+   jobs:
+   > Release PR #<num> (`vX.Y.Z`) is queued to auto-merge as a merge commit. It needs **one
+   > maintainer approval** (not the author). On approval it merges, then `release.yml` tags it and
+   > drafts the notes — review the draft and **publish** it; that deploys to Railway prod.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [develop, main]
   pull_request:
-    branches: [develop, main]
+    branches: [develop]
 
 jobs:
   build-test:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: deploy
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install Railway CLI
+        run: npm i -g @railway/cli
+
+      - name: Deploy to Railway (production)
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: railway up --ci --service web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  create-release:
+    if: >
+      github.event_name == 'push' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'develop' &&
+       startsWith(github.event.pull_request.title, 'chore: release v'))
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Determine version
+        id: ver
+        env:
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [ "$EVENT" = "push" ]; then
+            VERSION="$REF_NAME"
+          else
+            VERSION=$(printf '%s' "$TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          fi
+          if ! printf '%s' "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Could not resolve a vX.Y.Z version (event=$EVENT, title=$TITLE, ref=$REF_NAME)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing $VERSION"
+
+      - name: Tag the merge commit
+        if: github.event_name == 'pull_request'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION already exists — refusing to move it."
+            exit 1
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" "$SHA" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+      - name: Generate release notes
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          PREV=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vx "$VERSION" | head -1)
+          if [ -n "$PREV" ]; then RANGE="${PREV}..${VERSION}"; else RANGE="$VERSION"; fi
+
+          ALL=$(git log "$RANGE" --no-merges --pretty='%s' | grep -vE '^chore: release ')
+          strip='s/^[a-z]+(\([^)]*\))?!?:[[:space:]]*//'
+
+          FEATS=$(printf '%s\n' "$ALL" | grep -E '^feat'      | sed -E "$strip" | sed 's/^/- /')
+          FIXES=$(printf '%s\n' "$ALL" | grep -E '^fix'       | sed -E "$strip" | sed 's/^/- /')
+          OTHER=$(printf '%s\n' "$ALL" | grep -vE '^(feat|fix)' | sed -E "$strip" | sed 's/^/- /')
+          BREAKING=$(printf '%s\n' "$ALL" | grep -E '^[a-z]+(\([^)]*\))?!:' | sed -E "$strip" | sed 's/^/- /')
+
+          {
+            echo "<!-- Optional: add a one-line summary above What's changed, then publish. -->"
+            echo ""
+            echo "## What's changed"
+            echo ""
+            [ -n "$BREAKING" ] && { echo "### Breaking changes"; echo "$BREAKING"; echo ""; }
+            [ -n "$FEATS" ]    && { echo "### Features";         echo "$FEATS";    echo ""; }
+            [ -n "$FIXES" ]    && { echo "### Fixes";            echo "$FIXES";    echo ""; }
+            [ -n "$OTHER" ]    && { echo "### Other";            echo "$OTHER";    echo ""; }
+            if [ -n "$PREV" ]; then
+              echo "**Full changelog**: https://github.com/${REPO}/compare/${PREV}...${VERSION}"
+            fi
+          } > NOTES.md
+
+          echo "::group::Generated NOTES.md"
+          cat NOTES.md
+          echo "::endgroup::"
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          tag_name: ${{ steps.ver.outputs.version }}
+          name: ${{ steps.ver.outputs.version }}
+          body_path: NOTES.md


### PR DESCRIPTION
Mirrors the api repo's release + deploy setup.

## What changed
- **`release` skill** — one-command `develop → main` releases (open PR + queue auto-merge as a merge commit).
- **`release.yml`** — on the release-PR merge, tags `main` and auto-drafts a categorized changelog.
- **`deploy.yml`** — on **release publish**, deploys the tag to Railway prod via `railway up --ci --service web`.
- **`ci.yml`** — `pull_request` now only on `develop` (release PRs reuse develop's push CI; no duplicate runs).

## Required setup before it works (separate, one-time)
- Disable "Require linear history" on `main`; enable "Allow auto-merge" (being handled).
- Create a Railway **project token** scoped to production → GitHub secret `RAILWAY_TOKEN`.
- Disable Railway native auto-deploy on the web service.
- Confirm the Railway service name is `web` (in `deploy.yml`).