### PR TITLE
feat(boards): invite links with board-preview landing + redesigned modal

### DIFF
--- a/src/app/[locale]/(auth)/callback/page.tsx
+++ b/src/app/[locale]/(auth)/callback/page.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from "next-intl";
 
 import { getProfile, refreshToken } from "@/features/auth/api/client";
 import { ErrorAlert } from "@/features/auth/components/ErrorAlert";
+import { safeCallbackUrl } from "@/features/auth/lib/callbackUrl";
 import { useRouter } from "@/i18n/navigation";
 import { Button } from "@/shared/components/ui/button";
 import { Card, CardContent } from "@/shared/components/ui/card";
@@ -18,6 +19,7 @@ export default function CallbackPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const from = searchParams.get("from") ?? "login";
+  const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
   const apiError = useApiError();
 
   useEffect(() => {
@@ -49,7 +51,7 @@ export default function CallbackPage() {
         });
 
         router.refresh();
-        router.replace("/");
+        router.replace(callbackUrl);
       } catch {
         apiError.set({ code: "AUTHENTICATION_FAILED" });
       }

--- a/src/app/[locale]/boards/join/[code]/page.tsx
+++ b/src/app/[locale]/boards/join/[code]/page.tsx
@@ -1,0 +1,21 @@
+import { JoinInviteCard } from "@/features/boards/components/JoinInviteCard";
+import type { BoardPreview } from "@/features/boards/types/boards.types";
+import { getCurrentUser } from "@/lib/auth";
+import { serverApi } from "@/shared/lib/api/server";
+
+type Props = {
+  params: Promise<{ code: string }>;
+};
+
+export default async function JoinBoardPage({ params }: Props) {
+  const [{ code }, user] = await Promise.all([params, getCurrentUser()]);
+
+  const res = await serverApi.get<BoardPreview>(`/api/boards/preview?code=${encodeURIComponent(code)}`, {
+    authenticated: false,
+    next: { revalidate: 30 },
+  });
+
+  const preview = res.success ? (res.data ?? null) : null;
+
+  return <JoinInviteCard preview={preview} code={code} isAuthenticated={!!user} />;
+}

--- a/src/features/auth/components/GoogleButton.tsx
+++ b/src/features/auth/components/GoogleButton.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/shared/components/ui/button";
 
 import { getGoogleOAuthUrl } from "../api/client";
+import { useAuthStore } from "../store/auth.store";
 
 interface GoogleButtonProps {
   label: string;
@@ -24,9 +25,13 @@ const GoogleIcon = () => (
 );
 
 export function GoogleButton({ label }: GoogleButtonProps) {
+  const callbackUrl = useAuthStore((s) => s.callbackUrl);
+
   const handleClick = () => {
-    const returnTo = new URL("/callback?from=oauth", window.location.origin).toString();
-    const googleOAuthUrl = getGoogleOAuthUrl(returnTo);
+    const returnTo = new URL("/callback", window.location.origin);
+    returnTo.searchParams.set("from", "oauth");
+    if (callbackUrl !== "/") returnTo.searchParams.set("callbackUrl", callbackUrl);
+    const googleOAuthUrl = getGoogleOAuthUrl(returnTo.toString());
     window.location.assign(googleOAuthUrl);
   };
 

--- a/src/features/auth/components/SessionMonitor.tsx
+++ b/src/features/auth/components/SessionMonitor.tsx
@@ -11,6 +11,10 @@ import { refreshBackendAccessToken } from "@/shared/lib/api/refresh";
 // Mirror proxy.ts PUBLIC_ROUTES + GUEST_ONLY_ROUTES.
 const GUEST_PATHS = new Set(["/", "/schedule", "/standings", "/login", "/register", "/callback", "/how-it-works", "/rules", "/privacy", "/terms", "/faq"]);
 
+function isGuestPath(pathname: string): boolean {
+  return GUEST_PATHS.has(pathname) || pathname.startsWith("/boards/join/");
+}
+
 // SessionMonitor covers one specific gap: the user stays on the same page long
 // enough for the access token to expire without any navigation occurring
 //
@@ -36,7 +40,7 @@ export function SessionMonitor() {
   // signOut called). Skip guest pages to avoid a redirect loop.
   useEffect(() => {
     if (status !== "unauthenticated") return;
-    if (GUEST_PATHS.has(pathname)) return;
+    if (isGuestPath(pathname)) return;
 
     router.replace("/login");
   }, [status, pathname, router]);

--- a/src/features/auth/hooks/useLoginOtpStep.ts
+++ b/src/features/auth/hooks/useLoginOtpStep.ts
@@ -13,7 +13,7 @@ import { useApiError } from "@/shared/hooks/useApiError";
 
 export function useLoginOtpStep() {
   const router = useRouter();
-  const { identifier, reset } = useAuthStore();
+  const { identifier, callbackUrl, setCallbackUrl, reset } = useAuthStore();
   const countdown = useCountdown(30);
   const apiError = useApiError();
 
@@ -48,8 +48,10 @@ export function useLoginOtpStep() {
       return;
     }
 
-    reset();
-    router.replace("/");
+    // Navigate first, then clear only the callback. A full reset() would wipe `identifier`
+    // mid-step, tripping the OTP StepGuard into a redirect that overrides this navigation.
+    router.replace(callbackUrl);
+    setCallbackUrl("/");
   });
 
   const handleResend = async () => {

--- a/src/features/auth/hooks/useRegisterProfileStep.ts
+++ b/src/features/auth/hooks/useRegisterProfileStep.ts
@@ -13,7 +13,7 @@ import { useApiError } from "@/shared/hooks/useApiError";
 export function useRegisterProfileStep() {
   const router = useRouter();
   const apiError = useApiError();
-  const { identifier, otp, setProfile, reset } = useAuthStore();
+  const { identifier, otp, callbackUrl, setProfile, setCallbackUrl } = useAuthStore();
 
   const form = useForm<ProfileFormData>({
     resolver: zodResolver(profileSchema),
@@ -58,8 +58,10 @@ export function useRegisterProfileStep() {
       return;
     }
 
-    reset();
-    router.replace("/");
+    // Navigate first, then clear only the callback. A full reset() would wipe the fields
+    // the profile StepGuard requires, tripping it into a redirect that overrides this one.
+    router.replace(callbackUrl);
+    setCallbackUrl("/");
   });
 
   const handleBack = () => {

--- a/src/features/auth/lib/callbackUrl.ts
+++ b/src/features/auth/lib/callbackUrl.ts
@@ -1,0 +1,6 @@
+// Accept `raw` only if it's a same-origin path; reject protocol-relative/external to avoid open redirects.
+export function safeCallbackUrl(raw: string | null | undefined): string {
+  if (!raw || !raw.startsWith("/")) return "/";
+  if (raw.startsWith("//") || raw.startsWith("/\\")) return "/";
+  return raw;
+}

--- a/src/features/auth/store/auth.store.ts
+++ b/src/features/auth/store/auth.store.ts
@@ -22,9 +22,11 @@ interface AuthStoreState {
   username: string;
   firstName: string;
   lastName: string;
+  callbackUrl: string;
   setIdentifier: ({ identifier, purpose }: { identifier: string; purpose: OtpPurpose }) => void;
   setOtp: (otp: string) => void;
   setProfile: (profile: { username: string; firstName: string; lastName: string }) => void;
+  setCallbackUrl: (callbackUrl: string) => void;
   reset: () => void;
 }
 
@@ -35,6 +37,7 @@ const initialState = {
   username: "",
   firstName: "",
   lastName: "",
+  callbackUrl: "/",
 };
 
 export const useAuthStore = create<AuthStoreState>()(
@@ -44,6 +47,7 @@ export const useAuthStore = create<AuthStoreState>()(
       setIdentifier: ({ identifier, purpose }) => set({ identifier, purpose }),
       setOtp: (otp) => set({ otp }),
       setProfile: ({ username, firstName, lastName }) => set({ username, firstName, lastName }),
+      setCallbackUrl: (callbackUrl) => set({ callbackUrl }),
       reset: () => set(initialState),
     }),
     {
@@ -53,6 +57,8 @@ export const useAuthStore = create<AuthStoreState>()(
       partialize: (state) => ({
         identifier: state.identifier,
         purpose: state.purpose,
+        // Persisted so it survives the step navigation that drops URL query params.
+        callbackUrl: state.callbackUrl,
       }),
     }
   )

--- a/src/features/boards/components/InviteDialog.tsx
+++ b/src/features/boards/components/InviteDialog.tsx
@@ -1,14 +1,23 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Share2 } from "lucide-react";
+import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
+import { AvatarStack } from "@/shared/components/AvatarStack";
 import { CopyButton } from "@/shared/components/CopyButton";
 import { Button } from "@/shared/components/ui/button";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
+import { Skeleton } from "@/shared/components/ui/skeleton";
+import { canNativeShare, shareOrCopy } from "@/shared/lib/share";
 
-import { BOARD_DIALOG_WIDTH } from "../lib/boardDialog";
+import { boardMembersKey, fetchBoardMembers } from "../api/boards";
 import type { Board } from "../types/boards.types";
+
+import { BoardSquare } from "./BoardSquare";
 
 type Props = {
   board: Board;
@@ -16,25 +25,105 @@ type Props = {
   onOpenChange: (open: boolean) => void;
 };
 
+// Read client-only values without an SSR/hydration mismatch (server snapshot is the safe default).
+const emptySubscribe = () => () => {};
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">{children}</span>;
+}
+
 export function InviteDialog({ board, open, onOpenChange }: Props) {
   const t = useTranslations("boards.invite");
+  const tBoards = useTranslations("boards");
+  const { data: session } = useSession();
+
+  const origin = useSyncExternalStore(
+    emptySubscribe,
+    () => window.location.origin,
+    () => ""
+  );
+  const shareable = useSyncExternalStore(emptySubscribe, canNativeShare, () => false);
+
+  const membersQuery = useQuery({
+    queryKey: boardMembersKey(board.id, { limit: 8 }),
+    queryFn: () => fetchBoardMembers(board.id, { limit: 8 }),
+    enabled: open,
+    staleTime: 60_000,
+  });
+
+  const inviteUrl = board.join_code && origin ? `${origin}/boards/join/${board.join_code}` : "";
+  const viewerName = [session?.user?.first_name, session?.user?.last_name].filter(Boolean).join(" ") || session?.user?.username || t("you");
+  const othersCount = Math.max(0, board.member_count - 1);
+
+  const handleShare = async () => {
+    if (!inviteUrl) return;
+    const result = await shareOrCopy({ url: inviteUrl, title: t("title", { name: board.name }), text: t("shareText", { name: board.name }) });
+    if (result === "copied") toast.success(t("copiedLinkToast"));
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={BOARD_DIALOG_WIDTH}>
+      <DialogContent className="gap-5 sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{t("title", { name: board.name })}</DialogTitle>
-          <DialogDescription>{t("description")}</DialogDescription>
+          <div className="flex items-center gap-3">
+            <BoardSquare board={board} className="size-10 rounded-lg text-xs shadow-sm ring-1 ring-foreground/10" />
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <DialogTitle className="truncate text-left text-base">{t("title", { name: board.name })}</DialogTitle>
+              <span className="text-sm text-muted-foreground">
+                {tBoards(`privacy.${board.privacy}`)} · {tBoards("members", { count: board.member_count })}
+              </span>
+            </div>
+          </div>
         </DialogHeader>
-        <div className="flex items-center justify-between gap-3 rounded-lg border border-page-accent/20 bg-page-accent-soft px-4 py-3 font-mono text-lg tracking-widest text-page-accent-strong">
-          <span aria-label={board.join_code ?? ""}>{board.join_code ?? "—"}</span>
-          {board.join_code ? <CopyButton value={board.join_code} label={t("copy")} copiedLabel={t("copied")} onCopied={() => toast.success(t("copiedToast"))} /> : null}
+
+        <div className="flex items-center gap-3 rounded-lg border bg-muted/40 px-4 py-3">
+          {membersQuery.data ? (
+            <AvatarStack members={membersQuery.data.items} total={board.member_count} max={4} size="sm" tone="neutral" />
+          ) : (
+            <div className="flex">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="-ml-2 size-7 rounded-full ring-2 ring-background first:ml-0" />
+              ))}
+            </div>
+          )}
+          <span className="text-sm text-muted-foreground">{othersCount > 0 ? t("alreadyPlaying", { name: viewerName, count: othersCount }) : t("beFirst")}</span>
         </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            {t("close")}
-          </Button>
-        </DialogFooter>
+
+        {inviteUrl ? (
+          <div className="space-y-3">
+            <FieldLabel>{t("link")}</FieldLabel>
+            <div className="flex items-center justify-between gap-3 rounded-lg border bg-muted/40 py-2 pl-4 pr-2">
+              <span className="truncate text-sm text-muted-foreground" title={inviteUrl}>
+                {inviteUrl}
+              </span>
+              <CopyButton value={inviteUrl} variant="accent" iconOnly label={t("copy")} copiedLabel={t("copied")} onCopied={() => toast.success(t("copiedLinkToast"))} />
+            </div>
+          </div>
+        ) : null}
+
+        <div className="space-y-3">
+          <FieldLabel>{tBoards("manage.general.joinCode")}</FieldLabel>
+          <div className="flex items-center justify-between gap-3 rounded-lg border bg-muted/40 py-2 pl-4 pr-2">
+            <span aria-label={board.join_code ?? ""} className="truncate font-mono text-lg font-semibold tracking-[0.2em] text-foreground">
+              {board.join_code ?? "—"}
+            </span>
+            {board.join_code ? (
+              <CopyButton
+                value={board.join_code}
+                variant="accent"
+                iconOnly
+                label={t("copy")}
+                copiedLabel={t("copied")}
+                onCopied={() => toast.success(t("copiedToast"))}
+              />
+            ) : null}
+          </div>
+        </div>
+
+        <Button type="button" className="w-full gap-2 bg-page-accent text-white hover:bg-page-accent/90" onClick={handleShare} disabled={!inviteUrl}>
+          <Share2 className="size-4" aria-hidden />
+          {shareable ? t("shareInvite") : t("copyLink")}
+        </Button>
       </DialogContent>
     </Dialog>
   );

--- a/src/features/boards/components/JoinInviteCard.tsx
+++ b/src/features/boards/components/JoinInviteCard.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, Globe2, Link2Off, Lock } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import { useAuthStore } from "@/features/auth/store/auth.store";
+import { Link, useRouter } from "@/i18n/navigation";
+import { AvatarStack } from "@/shared/components/AvatarStack";
+import { Button } from "@/shared/components/ui/button";
+import { Card } from "@/shared/components/ui/card";
+import { translateApiError } from "@/shared/lib/api/errors";
+import { cn } from "@/shared/lib/utils";
+
+import { useJoinBoard } from "../hooks/useBoardMutations";
+import { rememberLastBoard } from "../lib/lastBoardCookie";
+import type { BoardPreview } from "../types/boards.types";
+
+import { BoardSquare } from "./BoardSquare";
+
+type Props = {
+  preview: BoardPreview | null;
+  code: string;
+  isAuthenticated: boolean;
+};
+
+// fill-mode-both holds the pre-animation state so staggered delays don't flash.
+const reveal = "animate-in fade-in-0 slide-in-from-bottom-2 duration-500 [animation-fill-mode:both]";
+
+export function JoinInviteCard({ preview, code, isAuthenticated }: Props) {
+  if (!preview) return <InvalidInvite />;
+  return <ValidInvite preview={preview} code={code} isAuthenticated={isAuthenticated} />;
+}
+
+function Shell({ children, footer }: { children: React.ReactNode; footer?: React.ReactNode }) {
+  return (
+    <div className="mx-auto flex min-h-[calc(100dvh-var(--header-height))] w-full max-w-md items-center justify-center px-4 py-8">
+      <Card className="w-full gap-0 bg-card py-0">
+        <div className="flex flex-col items-center gap-5 px-6 pt-9 pb-7 text-center">{children}</div>
+        {footer ? <div className="border-t border-border/60 bg-muted/40 px-6 py-3.5 text-center">{footer}</div> : null}
+      </Card>
+    </div>
+  );
+}
+
+function ValidInvite({ preview, code, isAuthenticated }: { preview: BoardPreview; code: string; isAuthenticated: boolean }) {
+  const t = useTranslations("boards.inviteLanding");
+  const tBoards = useTranslations("boards");
+  const tApiErrors = useTranslations("apiErrors");
+  const router = useRouter();
+  const mutation = useJoinBoard();
+  const [joined, setJoined] = useState(false);
+  const isPending = mutation.isPending || joined;
+
+  const isGlobal = preview.privacy === "global";
+  const PrivacyIcon = preview.privacy === "public" || isGlobal ? Globe2 : Lock;
+
+  async function handleJoin() {
+    if (isPending) return;
+
+    if (!isAuthenticated) {
+      useAuthStore.getState().setCallbackUrl(`/boards/join/${code}`);
+      router.push("/login");
+      return;
+    }
+
+    const res = await mutation.mutateAsync({ join_code: code.trim().toUpperCase() }).catch((error: Error) => {
+      toast.error(translateApiError(error, tApiErrors));
+      return null;
+    });
+    if (!res) return;
+
+    setJoined(true);
+    toast.success(t("success"));
+    rememberLastBoard(res.board_id);
+    router.push(`/boards/${res.board_id}`);
+    router.refresh();
+  }
+
+  return (
+    <Shell
+      footer={
+        <p className="text-xs text-muted-foreground">
+          {t("codeFooter")} <span className="font-mono font-medium tracking-widest text-foreground">{code.toUpperCase()}</span>
+        </p>
+      }
+    >
+      <p className={cn("text-lg font-semibold text-foreground", reveal)}>{t("invitedYou")}</p>
+
+      <span className={reveal} style={{ animationDelay: "80ms" }}>
+        <BoardSquare board={preview} className="size-16 rounded-xl text-xl shadow-md ring-1 ring-foreground/10" />
+      </span>
+
+      <div className={cn("flex flex-col items-center gap-2.5", reveal)} style={{ animationDelay: "140ms" }}>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
+          <PrivacyIcon className="size-3.5" aria-hidden />
+          {tBoards(`privacy.${preview.privacy}`)}
+        </span>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">{preview.name}</h1>
+      </div>
+
+      {preview.member_count > 0 ? (
+        <div className={cn("flex w-full items-center gap-3 rounded-lg border bg-muted/40 px-4 py-3", reveal)} style={{ animationDelay: "200ms" }}>
+          <AvatarStack members={preview.members} total={preview.member_count} max={4} size="sm" tone="neutral" />
+          <span className="text-left text-sm text-muted-foreground">{t("players", { count: preview.member_count })}</span>
+        </div>
+      ) : null}
+
+      <div className={cn("flex w-full flex-col gap-2", reveal)} style={{ animationDelay: "260ms" }}>
+        <Button className="group w-full gap-2" onClick={handleJoin} disabled={isPending}>
+          {t("join")}
+          <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" aria-hidden />
+        </Button>
+        <Button asChild variant="ghost" className="w-full">
+          <Link href={isAuthenticated ? "/boards" : "/"}>{t("cancel")}</Link>
+        </Button>
+      </div>
+    </Shell>
+  );
+}
+
+function InvalidInvite() {
+  const t = useTranslations("boards.inviteLanding");
+
+  return (
+    <Shell>
+      <div className="grid size-12 place-items-center rounded-lg bg-muted text-muted-foreground">
+        <Link2Off className="size-6" aria-hidden />
+      </div>
+      <h1 className="text-xl font-semibold text-foreground">{t("invalidTitle")}</h1>
+      <p className="text-sm text-muted-foreground">{t("invalidDescription")}</p>
+      <Button asChild variant="outline" className="w-full">
+        <Link href="/boards">{t("invalidCta")}</Link>
+      </Button>
+    </Shell>
+  );
+}

--- a/src/features/boards/types/boards.types.ts
+++ b/src/features/boards/types/boards.types.ts
@@ -40,6 +40,15 @@ export type BoardMembersPage = {
   has_more: boolean;
 };
 
+export type BoardMemberPreview = Pick<BoardMember, "user_id" | "username" | "first_name" | "last_name">;
+
+export type BoardPreview = {
+  name: string;
+  privacy: BoardPrivacy;
+  member_count: number;
+  members: BoardMemberPreview[];
+};
+
 export type CreateBoardInput = {
   name: string;
 };

--- a/src/i18n/messages/boards/en.json
+++ b/src/i18n/messages/boards/en.json
@@ -35,13 +35,29 @@
     "leaveSubtitle": "Step away from this board"
   },
   "invite": {
-    "trigger": "Invite friends",
     "copy": "Copy",
     "copied": "Copied",
     "copiedToast": "Join code copied",
     "title": "Invite to {name}",
-    "description": "Share this code with anyone you want on this board.",
-    "close": "Done"
+    "link": "Invite link",
+    "copyLink": "Copy link",
+    "copiedLinkToast": "Invite link copied",
+    "shareInvite": "Share invite",
+    "shareText": "Join my board on World Cup Pick'em: {name}",
+    "you": "You",
+    "alreadyPlaying": "{name} & {count, plural, one {# other} other {# others}} already playing",
+    "beFirst": "Be the first to invite your friends"
+  },
+  "inviteLanding": {
+    "invitedYou": "You've been invited to join",
+    "players": "{count, plural, one {# player is already competing in this board} other {# players are already competing in this board}}",
+    "join": "Join board",
+    "cancel": "Not now",
+    "success": "Welcome to the board",
+    "codeFooter": "Joining with code",
+    "invalidTitle": "Invite not found",
+    "invalidDescription": "This invite link is invalid or has expired. Ask for a fresh one.",
+    "invalidCta": "Go to boards"
   },
   "empty": {
     "title": "You're not on any board yet",

--- a/src/i18n/messages/boards/es.json
+++ b/src/i18n/messages/boards/es.json
@@ -35,13 +35,29 @@
     "leaveSubtitle": "Sal de este board"
   },
   "invite": {
-    "trigger": "Invitar amigos",
     "copy": "Copiar",
     "copied": "Copiado",
     "copiedToast": "Código copiado",
     "title": "Invitar a {name}",
-    "description": "Comparte este código con quien quieras invitar.",
-    "close": "Listo"
+    "link": "Enlace de invitación",
+    "copyLink": "Copiar enlace",
+    "copiedLinkToast": "Enlace copiado",
+    "shareInvite": "Compartir invitación",
+    "shareText": "Únete a mi board en World Cup Pick'em: {name}",
+    "you": "Tú",
+    "alreadyPlaying": "{name} y {count, plural, one {# persona más} other {# personas más}} ya están jugando",
+    "beFirst": "Sé el primero en invitar a tus amigos"
+  },
+  "inviteLanding": {
+    "invitedYou": "Te invitaron a unirte",
+    "players": "{count, plural, one {# jugador ya está compitiendo en este board} other {# jugadores ya están compitiendo en este board}}",
+    "join": "Unirme al board",
+    "cancel": "Ahora no",
+    "success": "Te uniste al board",
+    "codeFooter": "Te unes con el código",
+    "invalidTitle": "Invitación no encontrada",
+    "invalidDescription": "Este enlace de invitación no es válido o expiró. Pide uno nuevo.",
+    "invalidCta": "Ir a boards"
   },
   "empty": {
     "title": "Aún no estás en ningún board",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,6 +14,8 @@ const GUEST_ONLY_ROUTES = new Set(["/login", "/register", "/callback"]);
 // Routes that require a session. Everything else is public (the SEO-safe default —
 // new public pages like /standings need no change here). Compared against locale-stripped paths.
 function isProtectedPath(path: string): boolean {
+  // The invite landing under /boards/join/* is public.
+  if (path.startsWith("/boards/join/")) return false;
   return path === "/pickems" || path === "/profile" || path === "/boards" || path.startsWith("/boards/");
 }
 

--- a/src/shared/components/AvatarStack.tsx
+++ b/src/shared/components/AvatarStack.tsx
@@ -1,0 +1,45 @@
+import type { BoardMemberPreview } from "@/features/boards/types/boards.types";
+import { Avatar, AvatarFallback } from "@/shared/components/ui/avatar";
+import { avatarTone, getInitials } from "@/shared/lib/ui";
+import { cn } from "@/shared/lib/utils";
+
+type Size = "sm" | "md";
+type Tone = "tinted" | "neutral";
+
+const SIZE_CLASS: Record<Size, string> = {
+  sm: "size-7 text-2xs",
+  md: "size-9 text-xs",
+};
+
+type Props = {
+  members: BoardMemberPreview[];
+  total: number;
+  max?: number;
+  size?: Size;
+  tone?: Tone;
+  overlap?: boolean;
+  className?: string;
+};
+
+export function AvatarStack({ members, total, max = 5, size = "md", tone = "tinted", overlap = true, className }: Props) {
+  const shown = members.slice(0, max);
+  const overflow = total - shown.length;
+  const sizeClass = SIZE_CLASS[size];
+  const fallbackTone = (seed: string) => (tone === "neutral" ? "bg-foreground/90 text-background" : avatarTone(seed));
+  const ring = overlap ? "ring-2 ring-background" : "";
+
+  return (
+    <div className={cn("flex items-center", !overlap && "gap-1.5", className)}>
+      {shown.map((m) => (
+        <Avatar key={m.user_id} className={cn(sizeClass, ring, overlap && "-ml-2 first:ml-0")}>
+          <AvatarFallback className={cn("font-semibold", fallbackTone(m.user_id))}>
+            {getInitials(m.username, m.first_name ?? undefined, m.last_name ?? undefined)}
+          </AvatarFallback>
+        </Avatar>
+      ))}
+      {overflow > 0 ? (
+        <span className={cn(sizeClass, ring, overlap && "-ml-2", "grid place-items-center rounded-full bg-muted font-semibold text-muted-foreground")}>+{overflow}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/shared/components/CopyButton.tsx
+++ b/src/shared/components/CopyButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { Check, Copy } from "lucide-react";
 
 import { useClipboard } from "@/shared/hooks/useClipboard";
@@ -13,12 +14,13 @@ type Props = {
   copiedLabel?: string;
   className?: string;
   size?: "sm" | "default";
+  variant?: ComponentProps<typeof Button>["variant"];
   // Render just the clipboard icon (no text). The label still drives the accessible name.
   iconOnly?: boolean;
   onCopied?: () => void;
 };
 
-export function CopyButton({ value, label, copiedLabel, className, size = "sm", iconOnly = false, onCopied }: Props) {
+export function CopyButton({ value, label, copiedLabel, className, size = "sm", variant = "outline", iconOnly = false, onCopied }: Props) {
   const { copied, copy } = useClipboard();
   const text = copied ? (copiedLabel ?? "Copied") : (label ?? "Copy");
   const Icon = copied ? Check : Copy;
@@ -26,7 +28,7 @@ export function CopyButton({ value, label, copiedLabel, className, size = "sm", 
   return (
     <Button
       type="button"
-      variant="outline"
+      variant={variant}
       size={iconOnly ? "icon-sm" : size}
       className={cn(!iconOnly && "gap-1.5", className)}
       onClick={async () => {

--- a/src/shared/components/ui/button.tsx
+++ b/src/shared/components/ui/button.tsx
@@ -14,6 +14,7 @@ const buttonVariants = cva(
         outline:
           "border-border bg-card shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        accent: "bg-page-accent-soft text-page-accent-strong hover:bg-page-accent-soft/70",
         ghost: "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",

--- a/src/shared/lib/share.ts
+++ b/src/shared/lib/share.ts
@@ -1,0 +1,18 @@
+type ShareInput = { url: string; title?: string; text?: string };
+
+export function canNativeShare(): boolean {
+  return typeof navigator !== "undefined" && typeof navigator.share === "function";
+}
+
+export async function shareOrCopy({ url, title, text }: ShareInput): Promise<"shared" | "copied" | "dismissed"> {
+  if (canNativeShare()) {
+    try {
+      await navigator.share({ url, title, text });
+      return "shared";
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return "dismissed";
+    }
+  }
+  await navigator.clipboard.writeText(url);
+  return "copied";
+}

--- a/src/shared/lib/ui.ts
+++ b/src/shared/lib/ui.ts
@@ -6,3 +6,17 @@ export const getInitials = (username: string, firstName?: string, lastName?: str
   if (firstName && lastName) return `${firstName[0]}${lastName[0]}`.toUpperCase();
   return username.slice(0, 2).toUpperCase();
 };
+
+const AVATAR_TONES = [
+  "bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200",
+  "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200",
+  "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200",
+  "bg-sky-100 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200",
+  "bg-violet-100 text-violet-700 dark:bg-violet-500/20 dark:text-violet-200",
+] as const;
+
+export const avatarTone = (seed: string): string => {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) hash = (hash + seed.charCodeAt(i)) % AVATAR_TONES.length;
+  return AVATAR_TONES[hash];
+};


### PR DESCRIPTION
## Related issue

Closes #58

## What changed

- Public invite landing at `/boards/join/[code]` — SSR board preview (logo, member count, avatar stack) with a Join CTA; `/boards/join/*` opened in `proxy.ts` + `SessionMonitor`.
- Redesigned invite modal: shareable link, neutral stacked avatars, accent icon copy buttons, Web Share.
- Thread `callbackUrl` (store-based) through email-OTP, registration, and Google OAuth so invitees return to the board after sign-in.
- New shared primitives: `AvatarStack`, `accent` button variant, `shareOrCopy`; en/es i18n.

## How to test

- [ ] Requires backend `GET /api/boards/preview?code=` deployed.
- [ ] Logged out, open `/boards/join/<code>` → board preview shows (no bounce to login).
- [ ] Click Join → finish email-OTP login → land back on `/boards/join/<code>`.
- [ ] Repeat via Google OAuth and via "Create account" → both return to the invite.
- [ ] Open a board's Invite dialog → Copy link, Copy code, and Share all work.