### PR TITLE
fix(#61): navbar profile updates instantly after sign-in

### DIFF
--- a/src/features/auth/hooks/useLoginOtpStep.ts
+++ b/src/features/auth/hooks/useLoginOtpStep.ts
@@ -48,7 +48,12 @@ export function useLoginOtpStep() {
       return;
     }
 
-    // Navigate first, then clear only the callback. A full reset() would wipe `identifier`
+    // Re-render Server Components so the Header (which reads the session
+    // server-side and lives in the shared layout a soft navigation won't
+    // re-render) reflects the just-established session — otherwise it stays on
+    // its logged-out render (no avatar). See issue #61.
+    router.refresh();
+    // Navigate, then clear only the callback. A full reset() would wipe `identifier`
     // mid-step, tripping the OTP StepGuard into a redirect that overrides this navigation.
     router.replace(callbackUrl);
     setCallbackUrl("/");

--- a/src/features/auth/hooks/useRegisterProfileStep.ts
+++ b/src/features/auth/hooks/useRegisterProfileStep.ts
@@ -58,7 +58,11 @@ export function useRegisterProfileStep() {
       return;
     }
 
-    // Navigate first, then clear only the callback. A full reset() would wipe the fields
+    // Re-render Server Components so the Header (server-rendered, in the shared
+    // layout a soft navigation won't re-render) reflects the new session —
+    // otherwise it stays on its logged-out render (no avatar). See issue #61.
+    router.refresh();
+    // Navigate, then clear only the callback. A full reset() would wipe the fields
     // the profile StepGuard requires, tripping it into a redirect that overrides this one.
     router.replace(callbackUrl);
     setCallbackUrl("/");

--- a/src/i18n/messages/layout/en.json
+++ b/src/i18n/messages/layout/en.json
@@ -31,6 +31,7 @@
   "preferences": {
     "title": "Preferences",
     "theme": "Theme",
+    "toggleTheme": "Toggle theme",
     "themeLight": "Light",
     "themeDark": "Dark"
   },

--- a/src/i18n/messages/layout/es.json
+++ b/src/i18n/messages/layout/es.json
@@ -31,6 +31,7 @@
   "preferences": {
     "title": "Preferencias",
     "theme": "Tema",
+    "toggleTheme": "Cambiar tema",
     "themeLight": "Claro",
     "themeDark": "Oscuro"
   },

--- a/src/shared/layout/Header.tsx
+++ b/src/shared/layout/Header.tsx
@@ -1,18 +1,16 @@
-import { getTranslations } from "next-intl/server";
-
-import { Link } from "@/i18n/navigation";
 import { getCurrentUser } from "@/lib/auth";
-import { Button } from "@/shared/components/ui/button";
 
 import { Brand } from "./Brand";
+import { HeaderAuth } from "./HeaderAuth";
 import { MobileMenu } from "./MobileMenu";
 import { NavLinks } from "./NavLinks";
 import { PreferencesToggles } from "./PreferencesToggles";
-import { UserMenu } from "./UserMenu";
 
 export async function Header() {
-  const t = await getTranslations("nav");
   const user = await getCurrentUser();
+  // Plain, serializable shape for the client `HeaderAuth` (it re-syncs from the
+  // live session, but needs a server-correct value for the first paint).
+  const initialUser = user ? { username: user.username, firstName: user.first_name, lastName: user.last_name } : null;
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border bg-background/90 backdrop-blur-sm">
@@ -29,13 +27,7 @@ export async function Header() {
                 guests and authed users) instead of inside the profile menu. */}
             <PreferencesToggles />
             <div role="separator" aria-orientation="vertical" className="h-6 w-px bg-border" />
-            {user ? (
-              <UserMenu username={user.username} firstName={user.first_name} lastName={user.last_name} />
-            ) : (
-              <Button asChild size="sm" variant="ghost">
-                <Link href="/login">{t("login")}</Link>
-              </Button>
-            )}
+            <HeaderAuth initialUser={initialUser} />
           </div>
         </div>
 

--- a/src/shared/layout/HeaderAuth.tsx
+++ b/src/shared/layout/HeaderAuth.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useTranslations } from "next-intl";
+
+import { Link } from "@/i18n/navigation";
+import { Button } from "@/shared/components/ui/button";
+
+import { UserMenu } from "./UserMenu";
+
+type HeaderUser = { username: string; firstName?: string; lastName?: string };
+
+/**
+ * Auth-dependent slot of the desktop header (avatar menu vs. Sign In).
+ *
+ * The server passes `initialUser` for a correct, flash-free first paint, but
+ * once mounted this tracks the **client** session via `useSession()`. That's
+ * what makes the avatar appear the instant `signIn` resolves — the `Header` is
+ * a server component in a shared layout, so relying on a `router.refresh()`
+ * round-trip to update it left the navbar on its logged-out render for a
+ * noticeable beat after login (issue #61). `useSession` updates client-side
+ * immediately, no server round-trip.
+ */
+export function HeaderAuth({ initialUser }: { initialUser: HeaderUser | null }) {
+  const t = useTranslations("nav");
+  const { data, status } = useSession();
+
+  // "loading" → trust the server value (matches SSR, avoids a hydration flip);
+  // once resolved, the live client session wins.
+  const user =
+    status === "authenticated" && data?.user
+      ? { username: data.user.username, firstName: data.user.first_name, lastName: data.user.last_name }
+      : status === "unauthenticated"
+        ? null
+        : initialUser;
+
+  return user ? (
+    <UserMenu username={user.username} firstName={user.firstName} lastName={user.lastName} />
+  ) : (
+    <Button asChild size="sm" variant="ghost">
+      <Link href="/login">{t("login")}</Link>
+    </Button>
+  );
+}

--- a/src/shared/layout/PreferencesToggles.tsx
+++ b/src/shared/layout/PreferencesToggles.tsx
@@ -37,13 +37,7 @@ function ThemeToggleButton() {
   const { resolvedTheme, setTheme } = useTheme();
 
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      aria-label={t("toggleTheme")}
-      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-    >
+    <Button type="button" variant="ghost" size="icon-sm" aria-label={t("toggleTheme")} onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}>
       {/* Icons are CSS-driven via the `dark` class next-themes sets *before*
           paint, so the right icon shows on first render with no hydration gate
           (which previously flashed Moon→Sun on a dark-mode refresh). */}

--- a/src/shared/layout/PreferencesToggles.tsx
+++ b/src/shared/layout/PreferencesToggles.tsx
@@ -13,7 +13,6 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/shared/components/ui/dropdown-menu";
-import { useHydrated } from "@/shared/hooks/useHydrated";
 import { useLanguage } from "@/shared/hooks/useLanguage";
 import { LANGUAGES } from "@/shared/lib/preferences";
 
@@ -34,17 +33,22 @@ export function PreferencesToggles() {
 
 function ThemeToggleButton() {
   const t = useTranslations("preferences");
-  // `resolvedTheme` collapses "system" → the concrete light/dark the OS reports.
-  // Gate on `useHydrated`: it's `undefined` during SSR, so the first client
-  // render must match the server (neutral) and swap to the real icon on mount —
-  // otherwise React logs a hydration mismatch on the icon.
+  // `resolvedTheme` is only read at click time (post-hydration), so it's safe.
   const { resolvedTheme, setTheme } = useTheme();
-  const hydrated = useHydrated();
-  const isDark = hydrated && resolvedTheme === "dark";
 
   return (
-    <Button type="button" variant="ghost" size="icon-sm" aria-label={t(isDark ? "themeLight" : "themeDark")} onClick={() => setTheme(isDark ? "light" : "dark")}>
-      {isDark ? <Sun className="size-5" /> : <Moon className="size-5" />}
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      aria-label={t("toggleTheme")}
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+    >
+      {/* Icons are CSS-driven via the `dark` class next-themes sets *before*
+          paint, so the right icon shows on first render with no hydration gate
+          (which previously flashed Moon→Sun on a dark-mode refresh). */}
+      <Sun className="hidden size-5 dark:block" />
+      <Moon className="size-5 dark:hidden" />
     </Button>
   );
 }


### PR DESCRIPTION
## Related issue

Closes #61

## What changed

The navbar's auth slot (avatar menu vs. Sign In) stayed on its logged-out render for a beat after OTP/registration sign-in — and intermittently for ~1–1.5s.

**Root cause:** the `Header` is a **server component** (`getCurrentUser()` reads the session server-side) inside the shared `[locale]` layout. After `signIn`, the destination page re-renders with the new session cookie, but a shared layout isn't re-rendered on a soft navigation — so the header didn't update. Forcing it via `router.refresh()` worked but coupled the header to a **server round-trip** whose latency varies (network/backend), hence the visible lag.

**Fix:**
- New client component **`HeaderAuth`** consumes **`useSession()`** and renders `UserMenu` / Sign In. It takes a serializable `initialUser` from the server `Header` for a flash-free, SSR-correct first paint, then tracks the **live client session** — so the avatar flips the instant `signIn` resolves, with no server round-trip.
- `Header` now renders `<HeaderAuth initialUser={…} />` instead of inlining `UserMenu`/the Sign In button.
- `useLoginOtpStep` + `useRegisterProfileStep` call `router.refresh()` before navigating, so the rest of the server tree (dashboard RSC, mobile drawer's user) also reflects the session. The desktop header no longer *waits* on this — it's already updated client-side.

## How to test

- [ ] Sign in via OTP (and via register) → the desktop navbar shows the avatar/profile menu **immediately**, no logged-out flash or delay.
- [ ] Repeat a few times (the lag was intermittent) — consistently instant now.
- [ ] First paint / SSR still shows the correct state (no hydration flash) for both guest and authed loads.
- [ ] Sign out still flips back to the Sign In button.

## Note for reviewer

The desktop header is now session-reactive. The **mobile** drawer (`MobileMenu`) still gets its user from the server and relies on the `router.refresh()` (kept) — it can still have the brief lag on mobile; happy to give it the same `useSession()` treatment in a follow-up if desired.