### PR TITLE
fix: prevent stale session after refresh-token expiry and prefetch token churn

### DIFF
--- a/src/app/[locale]/(auth)/login/page.tsx
+++ b/src/app/[locale]/(auth)/login/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect } from "react";
 import { Mail } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { signOut } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Controller } from "react-hook-form";
 
@@ -27,9 +28,19 @@ type LoginStep = "identifier" | "otp";
 export default function LoginPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const pathname = usePathname();
   const stepParam = searchParams.get("step");
   const step: LoginStep = stepParam === "otp" || stepParam === "identifier" ? stepParam : "identifier";
   const stepIndex = step === "otp" ? 1 : 0;
+
+  // Arrived here because the middleware invalidated an unrecoverable session. It
+  // cleared the cookie, but the client SessionProvider still holds the session in
+  // memory after a soft nav — sign out to clear the stale navbar, then drop the flag.
+  useEffect(() => {
+    if (searchParams.get("session") !== "expired") return;
+    void signOut({ redirect: false });
+    router.replace(pathname);
+  }, [searchParams, router, pathname]);
 
   useEffect(() => {
     if (stepParam === null || step === stepParam) return;

--- a/src/app/api/auth/token/refresh/route.ts
+++ b/src/app/api/auth/token/refresh/route.ts
@@ -18,6 +18,7 @@ export async function POST(req: NextRequest) {
       headers: {
         ...(rt && { Cookie: `${REFRESH_COOKIE}=${rt}` }),
         ...forwardedClientHeaders(req),
+        "X-Refresh-Source": "client",
       },
     });
   } catch {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,6 +29,10 @@ const SECURE_COOKIES = process.env.NODE_ENV === "production";
 
 const handleI18nRouting = createMiddleware(routing);
 
+function isPrefetch(req: NextRequest): boolean {
+  return req.headers.has("next-router-prefetch") || req.headers.get("sec-purpose")?.includes("prefetch") === true || req.headers.get("purpose") === "prefetch";
+}
+
 // Splits a (possibly locale-prefixed) pathname into the active locale and the
 // unprefixed path. With `as-needed`, the default locale is served unprefixed.
 function splitLocale(pathname: string): { locale: Locale; path: string } {
@@ -83,21 +87,23 @@ export default async function proxy(req: NextRequest) {
     return NextResponse.redirect(localized("/login"));
   }
 
-  // Proactively refresh a near-expiry token so the RSC always renders with a fresh
-  // one (serverApi trusts the middleware to keep the token fresh).
-  if (accessToken && isTokenStale(accessToken)) {
+  // Skip for prefetches so bursts of prefetched links don't each rotate the token;
+  // the real navigation keeps it fresh.
+  if (accessToken && !isPrefetch(req)) {
     const refreshToken = req.cookies.get(REFRESH_COOKIE)?.value;
 
-    // No refresh token on the Next domain — session is unrecoverable. Clear the
-    // NextAuth cookie so the login page doesn't bounce the user back.
-    if (!refreshToken) return expiredSessionRedirect(localized("/login"));
+    // The session cookie can outlive the refresh-token cookie, leaving a stale
+    // logged-in shell that 401s. On a protected route a missing refresh token is
+    // unrecoverable — redirect to /login (clearing the session cookie).
+    if (!refreshToken) {
+      if (isProtectedPath(path)) return expiredSessionRedirect(localized("/login"));
+    } else if (isTokenStale(accessToken)) {
+      const refreshed = await refreshUpstream(refreshToken);
+      if (refreshed === "hard-failure") return expiredSessionRedirect(localized("/login"));
 
-    const refreshed = await refreshUpstream(refreshToken);
-    if (refreshed === "hard-failure") return expiredSessionRedirect(localized("/login"));
-
-    // On transient failure, let the request through — the RSC will hit a 401 and
-    // redirect to /login from there. Better than an incorrect forced sign-out.
-    if (refreshed) return applyRefreshedToken(req, token!, refreshed, i18nResponse);
+      // Transient failure: let it through; the RSC hits a 401 and redirects itself.
+      if (refreshed) return applyRefreshedToken(req, token!, refreshed, i18nResponse);
+    }
   }
 
   return i18nResponse;
@@ -115,7 +121,10 @@ async function refreshUpstream(refreshToken: string): Promise<RefreshSuccess | "
   try {
     const response = await fetch(`${process.env.BACKEND_API_URL}/api/auth/token/refresh`, {
       method: "POST",
-      headers: { Cookie: `${REFRESH_COOKIE}=${refreshToken}` },
+      headers: {
+        Cookie: `${REFRESH_COOKIE}=${refreshToken}`,
+        "X-Refresh-Source": "middleware",
+      },
     });
 
     if (!response.ok) {
@@ -188,6 +197,10 @@ async function applyRefreshedToken(req: NextRequest, token: JWT, refreshed: Refr
 // Redirects to (locale-aware) /login and clears the NextAuth session cookie so the
 // login page doesn't treat the user as still authenticated and bounce them back.
 function expiredSessionRedirect(target: URL): NextResponse {
+  // Flag it so the login page also clears the client-side NextAuth session: a soft
+  // navigation keeps it in memory, so clearing only the cookie here would leave the
+  // navbar showing the user as logged in.
+  target.searchParams.set("session", "expired");
   const response = NextResponse.redirect(target);
   response.cookies.set(SESSION_COOKIE, "", { maxAge: 0, path: "/" });
   return response;

--- a/src/shared/layout/Header.tsx
+++ b/src/shared/layout/Header.tsx
@@ -34,7 +34,7 @@ export async function Header() {
         {/* Mobile — logo left, burger right. Identity + preferences live in the drawer. */}
         <div className="flex w-full items-center justify-between lg:hidden">
           <Brand />
-          <MobileMenu user={user} />
+          <MobileMenu initialUser={user ? { username: user.username, first_name: user.first_name, last_name: user.last_name } : undefined} />
         </div>
       </div>
     </header>

--- a/src/shared/layout/MobileMenu.tsx
+++ b/src/shared/layout/MobileMenu.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { ChevronRight, Globe, LogOut, Palette } from "lucide-react";
+import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 
 import { logoutAndSignOut } from "@/features/auth/lib/logout";
@@ -24,12 +25,20 @@ type SessionUser = {
 };
 
 type MobileMenuProps = {
-  user?: SessionUser;
+  initialUser?: SessionUser;
 };
 
 const sectionLabel = "text-2xs font-medium uppercase tracking-wider text-muted-foreground";
 
-export function MobileMenu({ user }: MobileMenuProps) {
+export function MobileMenu({ initialUser }: MobileMenuProps) {
+  const { data, status } = useSession();
+  const user: SessionUser | undefined =
+    status === "authenticated" && data?.user
+      ? { username: data.user.username, first_name: data.user.first_name, last_name: data.user.last_name }
+      : status === "unauthenticated"
+        ? undefined
+        : initialUser;
+
   const t = useTranslations("nav");
   const tUser = useTranslations("userMenu");
   const tPref = useTranslations("preferences");


### PR DESCRIPTION
## Related issue

N/A — standalone auth fix.

## What changed

- Middleware skips token refresh on prefetch requests so prefetched-link bursts don't each rotate the token
- Protected-route requests with a missing refresh token now redirect to `/login`; non-protected routes pass through
- `expiredSessionRedirect` sets `?session=expired` so the login page also clears the in-memory client session
- Login page signs out client-side on `?session=expired` to drop the stale logged-in navbar after a soft nav
- `MobileMenu` reads live `useSession()` (seeded by `initialUser`) so the drawer reflects auth state instantly
- Refresh calls tag their origin via `X-Refresh-Source` (`client` / `middleware`)

## How to test

- [ ] Sign in, navigate around — confirm token refresh still works and no spurious sign-outs
- [ ] Let the refresh token expire/clear it, visit a protected route — confirm redirect to `/login` with a clean (logged-out) navbar
- [ ] On mobile, sign in and open the drawer — confirm it shows your identity immediately without a refresh
- [ ] Hover/prefetch several links rapidly — confirm the token isn't rotated repeatedly