### PR TITLE
feat: pick competition type, board summary tab, awards integration

### DIFF
--- a/src/app/[locale]/boards/[boardId]/competitions/[competitionId]/page.tsx
+++ b/src/app/[locale]/boards/[boardId]/competitions/[competitionId]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from "next/navigation";
 import { getLocale } from "next-intl/server";
 
+import { AWARDS_CACHE_TAG } from "@/features/awards/api/awards";
+import type { UserAwards } from "@/features/awards/types/awards.types";
 import { BOARDS_LIST_TAG, boardTag } from "@/features/boards/api/boards";
 import type { Board, BoardListItem } from "@/features/boards/types/boards.types";
 import { boardLeaderboardsTag, competitionsTag, LEADERBOARD_PAGE_SIZE, leaderboardTag } from "@/features/competitions/api/competitions";
@@ -88,11 +90,19 @@ export default async function CompetitionDetailPage({ params, searchParams }: Pr
     initialLeaderboard = { items, page: pagination.page, limit: pagination.limit, total: pagination.total, has_more: pagination.has_more };
   }
 
-  // Pick'em lock state seeds the header countdown + CTA, mirroring the board grid.
+  // Pick'em / awards lock state seeds the header countdown + CTA, mirroring the board grid.
   let pickem: { progress: UserPickem["progress"]; isLocked: boolean } | null = null;
   if (competition.type === "pickem") {
     const pickemRes = await serverApi.get<UserPickem>("/api/pickems", { authenticated: true, next: { revalidate: 30, tags: [PICKEMS_CACHE_TAG] } });
     if (pickemRes.success && pickemRes.data) pickem = { progress: pickemRes.data.progress, isLocked: pickemRes.data.is_locked };
+  }
+
+  let awards: { pickedTypes: UserAwards["picks"][number]["award_type"][]; isLocked: boolean } | null = null;
+  if (competition.type === "awards") {
+    const awardsRes = await serverApi.get<UserAwards>("/api/awards", { authenticated: true, next: { revalidate: 30, tags: [AWARDS_CACHE_TAG] } });
+    if (awardsRes.success && awardsRes.data) {
+      awards = { pickedTypes: awardsRes.data.picks.filter((p) => p.player != null).map((p) => p.award_type), isLocked: awardsRes.data.is_locked };
+    }
   }
 
   return (
@@ -102,6 +112,7 @@ export default async function CompetitionDetailPage({ params, searchParams }: Pr
       competition={competition}
       matches={matchesRes.data ?? []}
       pickem={pickem}
+      awards={awards}
       initialLeaderboard={initialLeaderboard}
     />
   );

--- a/src/app/[locale]/boards/[boardId]/competitions/[competitionId]/page.tsx
+++ b/src/app/[locale]/boards/[boardId]/competitions/[competitionId]/page.tsx
@@ -7,6 +7,7 @@ import { BOARDS_LIST_TAG, boardTag } from "@/features/boards/api/boards";
 import type { Board, BoardListItem } from "@/features/boards/types/boards.types";
 import { boardLeaderboardsTag, competitionsTag, LEADERBOARD_PAGE_SIZE, leaderboardTag } from "@/features/competitions/api/competitions";
 import { CompetitionDetailView } from "@/features/competitions/components/CompetitionDetailView";
+import { normalizeCompetition } from "@/features/competitions/lib/normalizeCompetition";
 import type { Competition, LeaderboardEntry, LeaderboardPage } from "@/features/competitions/types/competitions.types";
 import { PICKEMS_CACHE_TAG } from "@/features/pickems/api/pickems";
 import type { UserPickem } from "@/features/pickems/types/pickems.types";
@@ -64,7 +65,7 @@ export default async function CompetitionDetailPage({ params, searchParams }: Pr
   if (!matchesRes.success) throw new Error(matchesRes.error?.message ?? "Failed to load matches");
 
   const activeBoard = boardRes.data;
-  const competitions = competitionsRes.data ?? [];
+  const competitions = (competitionsRes.data ?? []).map(normalizeCompetition);
   const competition = competitions.find((c) => c.id === competitionIdNum);
   // Unknown/deleted competition — fall back to the board grid with a one-shot notice.
   if (!competition) {

--- a/src/app/[locale]/boards/[boardId]/page.tsx
+++ b/src/app/[locale]/boards/[boardId]/page.tsx
@@ -1,10 +1,12 @@
 import { notFound } from "next/navigation";
 import { getLocale } from "next-intl/server";
 
+import { AWARDS_CACHE_TAG } from "@/features/awards/api/awards";
+import type { UserAwards } from "@/features/awards/types/awards.types";
 import { BOARDS_LIST_TAG, boardTag } from "@/features/boards/api/boards";
 import { BoardDetailView } from "@/features/boards/components/BoardDetailView";
 import type { Board, BoardListItem } from "@/features/boards/types/boards.types";
-import { boardLeaderboardsTag, competitionsTag, leaderboardTag } from "@/features/competitions/api/competitions";
+import { competitionsTag } from "@/features/competitions/api/competitions";
 import type { Competition, LeaderboardEntry } from "@/features/competitions/types/competitions.types";
 import { PICKEMS_CACHE_TAG } from "@/features/pickems/api/pickems";
 import type { UserPickem } from "@/features/pickems/types/pickems.types";
@@ -20,10 +22,6 @@ type Props = {
   params: Promise<{ boardId: string }>;
   searchParams: Promise<{ competition?: string; notice?: string }>;
 };
-
-// Top of the leaderboard previewed on each competition card. Small + concurrent + cache-tagged so
-// the pick→revalidate flow already keeps them fresh.
-const TOP_PREVIEW_LIMIT = 3;
 
 export default async function BoardPage({ params, searchParams }: Props) {
   const [{ boardId }, { competition, notice }] = await Promise.all([params, searchParams]);
@@ -79,28 +77,25 @@ export default async function BoardPage({ params, searchParams }: Props) {
   const teams = collectTeams(matchesRes.data ?? []);
   const matches = matchesRes.data ?? [];
 
-  // Prefetch the top-N for every competition (concurrently) + the tournament pick'em progress (when
-  // the board has a pick'em — always, since it's the auto-seeded anchor).
+  // The competitions list already carries each card's top-3 preview, so we only need the viewer's
+  // own pick'em / awards progress for the card context (and only when the board has those types).
   const hasPickem = competitions.some((c) => c.type === "pickem");
-  const [topPreviews, pickemRes] = await Promise.all([
-    Promise.all(
-      competitions.map((c) =>
-        serverApi.get<LeaderboardEntry[]>(`/api/boards/${boardIdNum}/competitions/${c.id}/leaderboard?page=1&limit=${TOP_PREVIEW_LIMIT}`, {
-          authenticated: true,
-          next: { revalidate: 30, tags: [leaderboardTag(boardIdNum, c.id), boardLeaderboardsTag(boardIdNum)] },
-        })
-      )
-    ),
+  const hasAwards = competitions.some((c) => c.type === "awards");
+  const [pickemRes, awardsRes] = await Promise.all([
     hasPickem ? serverApi.get<UserPickem>("/api/pickems", { authenticated: true, next: { revalidate: 30, tags: [PICKEMS_CACHE_TAG] } }) : Promise.resolve(null),
+    hasAwards ? serverApi.get<UserAwards>("/api/awards", { authenticated: true, next: { revalidate: 30, tags: [AWARDS_CACHE_TAG] } }) : Promise.resolve(null),
   ]);
 
   const topThreeByCompetition: Record<number, LeaderboardEntry[]> = {};
-  competitions.forEach((c, i) => {
-    const res = topPreviews[i];
-    topThreeByCompetition[c.id] = res?.success && res.data ? res.data : [];
+  competitions.forEach((c) => {
+    topThreeByCompetition[c.id] = c.top_preview ?? [];
   });
 
   const pickem = pickemRes?.success && pickemRes.data ? { progress: pickemRes.data.progress, isLocked: pickemRes.data.is_locked } : null;
+  const awards =
+    awardsRes?.success && awardsRes.data
+      ? { pickedTypes: awardsRes.data.picks.filter((p) => p.player != null).map((p) => p.award_type), isLocked: awardsRes.data.is_locked }
+      : null;
 
   return (
     <BoardDetailView
@@ -113,6 +108,7 @@ export default async function BoardPage({ params, searchParams }: Props) {
       matches={matches}
       topThreeByCompetition={topThreeByCompetition}
       pickem={pickem}
+      awards={awards}
       boardNotFound={notice === "board-not-found"}
       competitionNotFound={notice === "competition-not-found"}
     />

--- a/src/app/[locale]/boards/[boardId]/page.tsx
+++ b/src/app/[locale]/boards/[boardId]/page.tsx
@@ -7,6 +7,7 @@ import { BOARDS_LIST_TAG, boardTag } from "@/features/boards/api/boards";
 import { BoardDetailView } from "@/features/boards/components/BoardDetailView";
 import type { Board, BoardListItem } from "@/features/boards/types/boards.types";
 import { competitionsTag } from "@/features/competitions/api/competitions";
+import { normalizeCompetition } from "@/features/competitions/lib/normalizeCompetition";
 import type { Competition, LeaderboardEntry } from "@/features/competitions/types/competitions.types";
 import { PICKEMS_CACHE_TAG } from "@/features/pickems/api/pickems";
 import type { UserPickem } from "@/features/pickems/types/pickems.types";
@@ -73,7 +74,7 @@ export default async function BoardPage({ params, searchParams }: Props) {
   if (!matchesRes.success) throw new Error(matchesRes.error?.message ?? "Failed to load matches");
 
   const activeBoard = boardRes.data;
-  const competitions = competitionsRes.data ?? [];
+  const competitions = (competitionsRes.data ?? []).map(normalizeCompetition);
   const teams = collectTeams(matchesRes.data ?? []);
   const matches = matchesRes.data ?? [];
 

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -11,7 +11,7 @@ type Props = {
   reset: () => void;
 };
 
-export default function GlobalError({ error, reset }: Props) {
+export default function GlobalError({ error }: Props) {
   const t = useTranslations("error");
 
   useEffect(() => {
@@ -30,7 +30,7 @@ export default function GlobalError({ error, reset }: Props) {
           <p className="text-sm text-muted-foreground">{t("description")}</p>
           <p className="text-sm text-muted-foreground">{t("hint")}</p>
         </div>
-        <Button onClick={reset} className="gap-1.5 bg-foreground text-background hover:bg-foreground/90">
+        <Button onClick={() => window.location.reload()} className="gap-1.5 bg-foreground text-background hover:bg-foreground/90">
           <RotateCw className="size-4" aria-hidden />
           {t("retry")}
         </Button>

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { useEffect } from "react";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, RotateCw } from "lucide-react";
 import { useTranslations } from "next-intl";
+
+import { Button } from "@/shared/components/ui/button";
 
 type Props = {
   error: Error & { digest?: string };
   reset: () => void;
 };
 
-export default function GlobalError({ error }: Props) {
+export default function GlobalError({ error, reset }: Props) {
   const t = useTranslations("error");
 
   useEffect(() => {
@@ -19,10 +21,19 @@ export default function GlobalError({ error }: Props) {
 
   return (
     <div className="container flex flex-1 items-center justify-center py-12">
-      <div className="flex max-w-md flex-col items-center gap-3 rounded-lg px-6 py-12 text-center">
-        <AlertTriangle className="size-6 text-muted-foreground" aria-hidden />
-        <h1 className="text-base font-semibold text-foreground">{t("title")}</h1>
-        <p className="text-sm text-muted-foreground">{t("description")}</p>
+      <div className="flex max-w-md flex-col items-center gap-5 px-6 py-12 text-center">
+        <span className="grid size-12 shrink-0 place-items-center rounded-full bg-muted">
+          <AlertTriangle className="size-6 text-muted-foreground" aria-hidden />
+        </span>
+        <div className="flex flex-col gap-1.5">
+          <h1 className="text-lg font-semibold text-foreground">{t("title")}</h1>
+          <p className="text-sm text-muted-foreground">{t("description")}</p>
+          <p className="text-sm text-muted-foreground">{t("hint")}</p>
+        </div>
+        <Button onClick={reset} className="gap-1.5 bg-foreground text-background hover:bg-foreground/90">
+          <RotateCw className="size-4" aria-hidden />
+          {t("retry")}
+        </Button>
       </div>
     </div>
   );

--- a/src/app/api/boards/[id]/summary/route.ts
+++ b/src/app/api/boards/[id]/summary/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+
+import { proxyToBackend } from "../../../_lib/proxy";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(req: NextRequest, { params }: Ctx) {
+  const { id } = await params;
+  return proxyToBackend(req, { path: `/api/boards/${id}/summary`, method: "GET" });
+}

--- a/src/features/awards/components/PlayerPicker.tsx
+++ b/src/features/awards/components/PlayerPicker.tsx
@@ -64,11 +64,7 @@ function PlayerPickerBody({ awardType, selectedPlayerId, onSelect }: { awardType
   const [countries, setCountries] = useState<string[]>([]);
   const [filtersOpen, setFiltersOpen] = useState(false);
 
-  // A position-locked award (Golden Glove) always constrains to its position,
-  // regardless of the toggle row (which is hidden in that case).
-  const activePositions = lockedPosition ? [lockedPosition] : positions;
-
-  const search = usePlayerSearch({ q: query, positions: activePositions, teamFifaCodes: countries, enabled: true });
+  const search = usePlayerSearch({ q: query, positions, lockedPosition, teamFifaCodes: countries, enabled: true });
   const popular = usePopularPicks(!search.hasCriteria);
   const { teams, isLoading: teamsLoading } = useFilterTeams(filtersOpen || countries.length > 0);
 

--- a/src/features/awards/hooks/usePlayerSearch.ts
+++ b/src/features/awards/hooks/usePlayerSearch.ts
@@ -11,9 +11,8 @@ import type { PlayerPosition } from "../types/awards.types";
 type Params = {
   q: string;
   positions: PlayerPosition[];
-  /** Selected country FIFA codes (AND with positions / query server-side). */
+  lockedPosition?: PlayerPosition;
   teamFifaCodes: string[];
-  /** Picker open — gates the request so closed pickers don't fetch. */
   enabled: boolean;
 };
 
@@ -23,15 +22,16 @@ type Params = {
  * `keepPreviousData` holds the prior results on screen while the next query
  * resolves so the list never flashes empty between keystrokes.
  */
-export function usePlayerSearch({ q, positions, teamFifaCodes, enabled }: Params) {
+export function usePlayerSearch({ q, positions, lockedPosition, teamFifaCodes, enabled }: Params) {
   const debouncedQ = useDebounce(q, PLAYER_SEARCH_DEBOUNCE_MS);
   const trimmed = debouncedQ.trim();
 
   const hasCriteria = trimmed.length > 0 || positions.length > 0 || teamFifaCodes.length > 0;
+  const requestPositions = lockedPosition ? [lockedPosition] : positions;
 
   const query = useQuery({
-    queryKey: [...PLAYERS_QUERY_KEY, { q: trimmed, positions, teamFifaCodes }],
-    queryFn: ({ signal }) => fetchPlayers({ q: trimmed, positions, team_fifa_codes: teamFifaCodes }, signal),
+    queryKey: [...PLAYERS_QUERY_KEY, { q: trimmed, positions: requestPositions, teamFifaCodes }],
+    queryFn: ({ signal }) => fetchPlayers({ q: trimmed, positions: requestPositions, team_fifa_codes: teamFifaCodes }, signal),
     enabled: enabled && hasCriteria,
     placeholderData: keepPreviousData,
     staleTime: 60_000,

--- a/src/features/boards/components/BoardDetailView.tsx
+++ b/src/features/boards/components/BoardDetailView.tsx
@@ -6,6 +6,8 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
+import type { AwardType } from "@/features/awards/types/awards.types";
+import { BoardSummaryTab, type SummaryColumn } from "@/features/competitions/components/BoardSummaryTab";
 import { CompetitionsTab } from "@/features/competitions/components/CompetitionsTab";
 import { CreateCompetitionWizard } from "@/features/competitions/components/CreateCompetitionWizard";
 import type { Competition, LeaderboardEntry } from "@/features/competitions/types/competitions.types";
@@ -33,6 +35,7 @@ type Props = {
   matches: Match[];
   topThreeByCompetition: Record<number, LeaderboardEntry[]>;
   pickem: { progress: PickemProgress | null; isLocked: boolean } | null;
+  awards: { pickedTypes: AwardType[]; isLocked: boolean } | null;
   boardNotFound?: boolean;
   competitionNotFound?: boolean;
 };
@@ -49,6 +52,7 @@ export function BoardDetailView({
   matches,
   topThreeByCompetition,
   pickem,
+  awards,
   boardNotFound = false,
   competitionNotFound = false,
 }: Props) {
@@ -60,7 +64,8 @@ export function BoardDetailView({
   const [wizardOpen, setWizardOpen] = useState(false);
   const [query, setQuery] = useState("");
 
-  const tab: BoardTabKey = searchParams.get(TAB_PARAM) === "members" ? "members" : "competitions";
+  const tabParam = searchParams.get(TAB_PARAM);
+  const tab: BoardTabKey = tabParam === "members" ? "members" : tabParam === "summary" ? "summary" : "competitions";
 
   useEffect(() => {
     rememberLastBoard(activeBoard.id);
@@ -88,6 +93,17 @@ export function BoardDetailView({
   const canManage = canManageBoard(activeBoard.viewer.role);
 
   const pickemContext = useMemo(() => ({ progress: pickem?.progress ?? null, isLocked: pickem?.isLocked ?? false }), [pickem]);
+  const awardsContext = useMemo(() => ({ pickedTypes: awards?.pickedTypes ?? [], isLocked: awards?.isLocked ?? false }), [awards]);
+
+  const summaryColumns = useMemo<SummaryColumn[]>(() => {
+    const present = new Set(competitions.map((c) => c.type));
+    const cols: SummaryColumn[] = [];
+    if (present.has("pickem")) cols.push("pickem");
+    if (present.has("match")) cols.push("custom");
+    if (present.has("pick")) cols.push("pick");
+    if (present.has("awards")) cols.push("awards");
+    return cols;
+  }, [competitions]);
 
   function setTab(next: BoardTabKey) {
     const params = new URLSearchParams(searchParams);
@@ -99,6 +115,7 @@ export function BoardDetailView({
 
   const tabs = [
     { key: "competitions" as const, label: tBoards("tabs.competitions") },
+    { key: "summary" as const, label: tBoards("tabs.summary") },
     { key: "members" as const, label: tBoards("tabs.members") },
   ];
 
@@ -146,17 +163,29 @@ export function BoardDetailView({
             teamsByCode={teamsByCode}
             topThreeByCompetition={topThreeByCompetition}
             pickemContext={pickemContext}
+            awardsContext={awardsContext}
             query={query}
             canManage={canManage}
             canCreate={canCreate}
             onCreate={() => setWizardOpen(true)}
           />
+        ) : tab === "summary" ? (
+          <BoardSummaryTab boardId={activeBoard.id} currentUserId={currentUserId} columns={summaryColumns} enabled={tab === "summary"} />
         ) : (
           <MembersTab board={activeBoard} currentUserId={currentUserId} enabled={tab === "members"} />
         )}
       </section>
 
-      {canCreate ? <CreateCompetitionWizard open={wizardOpen} onOpenChange={setWizardOpen} boardId={activeBoard.id} teams={teams} matches={matches} /> : null}
+      {canCreate ? (
+        <CreateCompetitionWizard
+          open={wizardOpen}
+          onOpenChange={setWizardOpen}
+          boardId={activeBoard.id}
+          teams={teams}
+          matches={matches}
+          existingTypes={competitions.map((c) => c.type)}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/features/boards/components/BoardHeader.tsx
+++ b/src/features/boards/components/BoardHeader.tsx
@@ -73,7 +73,7 @@ export function BoardHeader({ boards, activeBoard }: Props) {
           <BoardHeaderAvatars board={activeBoard} />
           <div className="flex items-center gap-2">
             {showInvite ? (
-              <Button variant="outline" size="sm" className="gap-1.5 px-3.5" onClick={() => setInviteOpen(true)}>
+              <Button variant="outline" size="sm" className="gap-1.5 px-3.5 sm:px-6" onClick={() => setInviteOpen(true)}>
                 <UserPlus className="size-4" aria-hidden />
                 {t("switcher.invite")}
               </Button>

--- a/src/features/boards/components/BoardTabs.tsx
+++ b/src/features/boards/components/BoardTabs.tsx
@@ -3,7 +3,7 @@
 import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
 import { cn } from "@/shared/lib/utils";
 
-export type BoardTabKey = "competitions" | "members";
+export type BoardTabKey = "competitions" | "summary" | "members";
 
 type TabDef = { key: BoardTabKey; label: string };
 

--- a/src/features/boards/components/DeleteBoardDialog.tsx
+++ b/src/features/boards/components/DeleteBoardDialog.tsx
@@ -5,9 +5,9 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { useRouter } from "@/i18n/navigation";
+import { ConfirmByTyping } from "@/shared/components/ConfirmByTyping";
 import { Button } from "@/shared/components/ui/button";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
-import { Input } from "@/shared/components/ui/input";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
 import { useAutoFocusUnlessMobile } from "@/shared/hooks/useAutoFocusUnlessMobile";
 import { translateApiError } from "@/shared/lib/api/errors";
 
@@ -54,11 +54,25 @@ export function DeleteBoardDialog({ board, open, onOpenChange }: Props) {
       <DialogContent onOpenAutoFocus={focus.onOpenAutoFocus} className={BOARD_DIALOG_WIDTH}>
         <DialogHeader>
           <DialogTitle>{t("delete.confirm", { name: board.name })}</DialogTitle>
-          <DialogDescription>{t("delete.confirmDescription")}</DialogDescription>
         </DialogHeader>
-        <Input value={typed} onChange={(event) => setTyped(event.target.value)} autoFocus={focus.autoFocus} aria-label={board.name} />
+        <ConfirmByTyping
+          inputId="delete-board-confirm"
+          warning={t("delete.description")}
+          label={t.rich("delete.typeToConfirm", { name: board.name, b: (chunks) => <span className="font-medium text-foreground">{chunks}</span> })}
+          placeholder={board.name}
+          value={typed}
+          onChange={setTyped}
+          autoFocus={focus.autoFocus}
+        />
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} className="sm:min-w-24 sm:px-6">
+          <Button
+            variant="outline"
+            onClick={() => {
+              setTyped("");
+              onOpenChange(false);
+            }}
+            className="sm:min-w-24 sm:px-6"
+          >
             {t("delete.cancel")}
           </Button>
           <Button variant="destructive" disabled={typed !== board.name || remove.isPending} onClick={handleDelete} className="sm:min-w-24 sm:px-6">

--- a/src/features/boards/components/ManageBoardGeneral.tsx
+++ b/src/features/boards/components/ManageBoardGeneral.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { useRouter } from "@/i18n/navigation";
+import { ConfirmByTyping } from "@/shared/components/ConfirmByTyping";
 import { CopyButton } from "@/shared/components/CopyButton";
 import { Button } from "@/shared/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
@@ -162,11 +163,25 @@ export function ManageBoardGeneral({ board, onClose, onPermissionLost }: Props) 
         <DialogContent onOpenAutoFocus={deleteFocus.onOpenAutoFocus} className={BOARD_DIALOG_WIDTH}>
           <DialogHeader>
             <DialogTitle>{t("delete.confirm", { name: board.name })}</DialogTitle>
-            <DialogDescription>{t("delete.confirmDescription")}</DialogDescription>
           </DialogHeader>
-          <Input value={deleteTyped} onChange={(event) => setDeleteTyped(event.target.value)} autoFocus={deleteFocus.autoFocus} />
+          <ConfirmByTyping
+            inputId="manage-delete-board-confirm"
+            warning={t("delete.description")}
+            label={t.rich("delete.typeToConfirm", { name: board.name, b: (chunks) => <span className="font-medium text-foreground">{chunks}</span> })}
+            placeholder={board.name}
+            value={deleteTyped}
+            onChange={setDeleteTyped}
+            autoFocus={deleteFocus.autoFocus}
+          />
           <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmDelete(false)} className="sm:min-w-24 sm:px-6">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setDeleteTyped("");
+                setConfirmDelete(false);
+              }}
+              className="sm:min-w-24 sm:px-6"
+            >
               {t("delete.cancel")}
             </Button>
             <Button variant="destructive" disabled={deleteTyped !== board.name || remove.isPending} onClick={handleDelete} className="sm:min-w-24 sm:px-6">

--- a/src/features/competitions/api/competitions.ts
+++ b/src/features/competitions/api/competitions.ts
@@ -1,6 +1,7 @@
 import { api } from "@/shared/lib/api/client";
 import { ApiClientError } from "@/shared/lib/api/errors";
 
+import { normalizeCompetition } from "../lib/normalizeCompetition";
 import type { BoardSummaryEntry, BoardSummaryPage, Competition, CreateCompetitionInput, LeaderboardEntry, LeaderboardPage } from "../types/competitions.types";
 
 export const competitionsTag = (boardId: number) => `competitions:${boardId}` as const;
@@ -19,7 +20,7 @@ export const LEADERBOARD_PAGE_SIZE = 10;
 export async function fetchCompetitions(boardId: number): Promise<Competition[]> {
   const res = await api.get<Competition[]>(`/api/boards/${boardId}/competitions`, { authenticated: true });
   if (!res.success || !res.data) throw new Error(res.error?.message ?? "Failed to load competitions");
-  return res.data;
+  return res.data.map(normalizeCompetition);
 }
 
 export async function fetchLeaderboard(

--- a/src/features/competitions/api/competitions.ts
+++ b/src/features/competitions/api/competitions.ts
@@ -1,7 +1,7 @@
 import { api } from "@/shared/lib/api/client";
 import { ApiClientError } from "@/shared/lib/api/errors";
 
-import type { Competition, CreateCompetitionInput, LeaderboardEntry, LeaderboardPage } from "../types/competitions.types";
+import type { BoardSummaryEntry, BoardSummaryPage, Competition, CreateCompetitionInput, LeaderboardEntry, LeaderboardPage } from "../types/competitions.types";
 
 export const competitionsTag = (boardId: number) => `competitions:${boardId}` as const;
 export const leaderboardTag = (boardId: number, competitionId: number) => `leaderboard:${boardId}:${competitionId}` as const;
@@ -10,7 +10,8 @@ export const leaderboardTag = (boardId: number, competitionId: number) => `leade
 export const boardLeaderboardsTag = (boardId: number) => `leaderboards:${boardId}` as const;
 
 export const competitionsKey = (boardId: number) => ["competitions", "list", boardId] as const;
-export const leaderboardKey = (boardId: number, competitionId: number, params: { page: number; q: string }) =>
+export const boardSummaryKey = (boardId: number, params: { page: number; q: string; sort: string; dir: string }) => ["boards", "summary", boardId, params] as const;
+export const leaderboardKey = (boardId: number, competitionId: number, params: { page: number; q: string; sort: string; dir: string }) =>
   ["competitions", "leaderboard", boardId, competitionId, params] as const;
 
 export const LEADERBOARD_PAGE_SIZE = 10;
@@ -21,14 +22,38 @@ export async function fetchCompetitions(boardId: number): Promise<Competition[]>
   return res.data;
 }
 
-export async function fetchLeaderboard(boardId: number, competitionId: number, params: { page?: number; limit?: number; q?: string } = {}): Promise<LeaderboardPage> {
+export async function fetchLeaderboard(
+  boardId: number,
+  competitionId: number,
+  params: { page?: number; limit?: number; q?: string; sort?: string; dir?: string } = {}
+): Promise<LeaderboardPage> {
   const search = new URLSearchParams();
   if (params.page) search.set("page", String(params.page));
   if (params.limit) search.set("limit", String(params.limit));
   if (params.q) search.set("q", params.q);
+  if (params.sort && params.sort !== "total") search.set("sort", params.sort);
+  if (params.dir && params.dir !== "desc") search.set("dir", params.dir);
   const qs = search.toString();
   const res = await api.get<LeaderboardEntry[]>(`/api/boards/${boardId}/competitions/${competitionId}/leaderboard${qs ? `?${qs}` : ""}`, { authenticated: true });
   if (!res.success || !res.data) throw new Error(res.error?.message ?? "Failed to load leaderboard");
+  const fallback = { page: params.page ?? 1, limit: params.limit ?? res.data.length, total: res.data.length, has_more: false };
+  const pagination = res.pagination ?? fallback;
+  return { items: res.data, page: pagination.page, limit: pagination.limit, total: pagination.total, has_more: pagination.has_more };
+}
+
+export async function fetchBoardSummary(
+  boardId: number,
+  params: { page?: number; limit?: number; q?: string; sort?: string; dir?: string } = {}
+): Promise<BoardSummaryPage> {
+  const search = new URLSearchParams();
+  if (params.page) search.set("page", String(params.page));
+  if (params.limit) search.set("limit", String(params.limit));
+  if (params.q) search.set("q", params.q);
+  if (params.sort && params.sort !== "total") search.set("sort", params.sort);
+  if (params.dir && params.dir !== "desc") search.set("dir", params.dir);
+  const qs = search.toString();
+  const res = await api.get<BoardSummaryEntry[]>(`/api/boards/${boardId}/summary${qs ? `?${qs}` : ""}`, { authenticated: true });
+  if (!res.success || !res.data) throw new Error(res.error?.message ?? "Failed to load summary");
   const fallback = { page: params.page ?? 1, limit: params.limit ?? res.data.length, total: res.data.length, has_more: false };
   const pagination = res.pagination ?? fallback;
   return { items: res.data, page: pagination.page, limit: pagination.limit, total: pagination.total, has_more: pagination.has_more };

--- a/src/features/competitions/components/BoardSummaryTab.tsx
+++ b/src/features/competitions/components/BoardSummaryTab.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronsUpDown, ChevronUp, Crown, Search, User, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Avatar, AvatarFallback } from "@/shared/components/ui/avatar";
+import { Input } from "@/shared/components/ui/input";
+import { Skeleton } from "@/shared/components/ui/skeleton";
+import { useDebounce } from "@/shared/hooks/useDebounce";
+import { displayName, getInitials } from "@/shared/lib/ui";
+import { cn } from "@/shared/lib/utils";
+
+import { LEADERBOARD_PAGE_SIZE } from "../api/competitions";
+import { useBoardSummary } from "../hooks/useBoardSummary";
+import type { BoardSummaryEntry } from "../types/competitions.types";
+
+import { LeaderboardPagination } from "./LeaderboardPagination";
+
+// Which per-type subtotal columns the board has (custom = match competitions).
+export type SummaryColumn = "pickem" | "custom" | "pick" | "awards";
+
+type SortKey = SummaryColumn | "total";
+type SortDir = "asc" | "desc";
+
+type Props = {
+  boardId: number;
+  currentUserId: string;
+  columns: SummaryColumn[];
+  enabled: boolean;
+};
+
+export function BoardSummaryTab({ boardId, currentUserId, columns, enabled }: Props) {
+  const t = useTranslations("competitions.leaderboard");
+  const tCol = useTranslations("competitions.summary.columns");
+  const [q, setQ] = useState("");
+  const [page, setPage] = useState(1);
+  const [sort, setSort] = useState<SortKey>("total");
+  const [dir, setDir] = useState<SortDir>("desc");
+  const debouncedQ = useDebounce(q, 250);
+
+  const query = useBoardSummary({ boardId, page, q: debouncedQ, sort, dir, enabled });
+  const items = query.data?.items ?? [];
+  const totalCount = query.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / LEADERBOARD_PAGE_SIZE));
+  const isLoading = query.isFetching && items.length === 0;
+  const emptyLabel = debouncedQ.length > 0 ? t("noResults") : t("empty");
+
+  // Sortable keys in display order: the per-type subtotals, then the overall total.
+  const sortKeys: SortKey[] = [...columns, "total"];
+  const sortLabel = (key: SortKey) => (key === "total" ? t("columns.total") : tCol(key));
+
+  function onSearch(value: string) {
+    setQ(value);
+    setPage(1);
+  }
+
+  // Click a new column → sort it descending; click the active column → flip direction.
+  function onSort(key: SortKey) {
+    if (key === sort) {
+      setDir((d) => (d === "desc" ? "asc" : "desc"));
+    } else {
+      setSort(key);
+      setDir("desc");
+    }
+    setPage(1);
+  }
+
+  return (
+    <div className="flex flex-col gap-3.5">
+      <div className="relative sm:max-w-xs">
+        <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
+        <Input value={q} onChange={(e) => onSearch(e.target.value)} placeholder={t("search")} className="h-9 pl-9" />
+        {q ? (
+          <button
+            type="button"
+            onClick={() => onSearch("")}
+            className="absolute top-1/2 right-2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+            aria-label={t("search")}
+          >
+            <X className="size-3.5" aria-hidden />
+          </button>
+        ) : null}
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-foreground/10 bg-card shadow-xs">
+        {/* Desktop */}
+        <table className="hidden w-full border-collapse text-sm md:table">
+          <thead>
+            <tr className="border-b border-border bg-muted/40 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+              <th className="w-12 px-4 py-2.5 text-center">{t("columns.rank")}</th>
+              <th className="w-full px-4 py-2.5 text-left">{t("columns.member")}</th>
+              {columns.map((col) => (
+                <SortHeader key={col} label={tCol(col)} active={sort === col} dir={dir} onClick={() => onSort(col)} />
+              ))}
+              <SortHeader label={t("columns.total")} active={sort === "total"} dir={dir} onClick={() => onSort("total")} />
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              Array.from({ length: LEADERBOARD_PAGE_SIZE }).map((_, i) => (
+                <tr key={i} className="border-b border-border/60 last:border-b-0">
+                  <td className="px-4 py-2.5 text-center">
+                    <Skeleton className="mx-auto h-4 w-5" />
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <Skeleton className="h-4 w-32" />
+                  </td>
+                  {columns.map((col) => (
+                    <td key={col} className="px-4 py-2.5 text-center">
+                      <Skeleton className="mx-auto h-4 w-8" />
+                    </td>
+                  ))}
+                  <td className="px-4 py-2.5 text-center">
+                    <Skeleton className="mx-auto h-4 w-8" />
+                  </td>
+                </tr>
+              ))
+            ) : items.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length + 3} className="py-10 text-center text-sm text-muted-foreground">
+                  {emptyLabel}
+                </td>
+              </tr>
+            ) : (
+              items.map((entry) => {
+                const isMe = entry.member.user_id === currentUserId;
+                return (
+                  <tr
+                    key={entry.member.user_id}
+                    className={cn("border-b border-border/60 tabular-nums transition-colors last:border-b-0 hover:bg-muted", isMe && "bg-muted/40")}
+                  >
+                    <td className="px-4 py-2.5 text-center">
+                      <RankBadge rank={entry.rank} />
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <MemberCell entry={entry} isMe={isMe} youLabel={t("you")} />
+                    </td>
+                    {columns.map((col) => (
+                      <td key={col} className="px-4 py-2.5 text-center text-muted-foreground">
+                        {entry[col].toLocaleString()}
+                      </td>
+                    ))}
+                    <td className="px-4 py-2.5 text-center font-semibold text-foreground">{entry.total.toLocaleString()}</td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+
+        {/* Mobile */}
+        <div className="md:hidden">
+          <div className="flex flex-wrap gap-1.5 border-b border-border px-3 py-2.5">
+            {sortKeys.map((key) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => onSort(key)}
+                aria-pressed={sort === key}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-2xs font-medium transition-colors",
+                  sort === key ? "border-page-accent-strong/30 bg-page-accent-soft text-page-accent-strong" : "border-border text-muted-foreground hover:bg-muted"
+                )}
+              >
+                {sortLabel(key)}
+                {sort === key ? <DirChevron dir={dir} /> : null}
+              </button>
+            ))}
+          </div>
+          {isLoading ? (
+            <ul className="divide-y divide-border">
+              {Array.from({ length: LEADERBOARD_PAGE_SIZE }).map((_, i) => (
+                <li key={i} className="flex items-center gap-3 px-3 py-2.5">
+                  <Skeleton className="h-3.5 w-6" />
+                  <Skeleton className="h-9 flex-1" />
+                </li>
+              ))}
+            </ul>
+          ) : items.length === 0 ? (
+            <p className="py-10 text-center text-sm text-muted-foreground">{emptyLabel}</p>
+          ) : (
+            <ul className="divide-y divide-border">
+              {items.map((entry) => {
+                const isMe = entry.member.user_id === currentUserId;
+                return (
+                  <li key={entry.member.user_id} className={cn("flex items-center gap-3 px-3 py-2.5", isMe && "bg-page-accent-soft/60")}>
+                    <span className="w-6 shrink-0 text-center">
+                      <RankBadge rank={entry.rank} />
+                    </span>
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                      <MemberCell entry={entry} isMe={isMe} youLabel={t("you")} />
+                      <span className="flex flex-wrap gap-x-2 text-2xs text-muted-foreground tabular-nums">
+                        {columns.map((col) => (
+                          <span key={col}>
+                            {tCol(col)} {entry[col].toLocaleString()}
+                          </span>
+                        ))}
+                      </span>
+                    </div>
+                    <span className="shrink-0 font-mono text-base font-semibold tabular-nums">{entry.total.toLocaleString()}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        {totalPages > 1 ? (
+          <div className="border-t border-border/60 px-4 py-3">
+            <LeaderboardPagination
+              page={page}
+              totalPages={totalPages}
+              shown={items.length}
+              total={totalCount}
+              onPrev={() => setPage((p) => Math.max(1, p - 1))}
+              onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+              isFetching={query.isFetching}
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SortHeader({ label, active, dir, onClick }: { label: string; active: boolean; dir: SortDir; onClick: () => void }) {
+  return (
+    <th className="w-20 px-4 py-2.5 text-center whitespace-nowrap" aria-sort={active ? (dir === "asc" ? "ascending" : "descending") : undefined}>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn("inline-flex cursor-pointer items-center gap-1 transition-colors hover:text-foreground", active && "text-foreground")}
+      >
+        {label}
+        {active ? <DirChevron dir={dir} /> : <ChevronsUpDown className="size-3 text-muted-foreground/50" aria-hidden />}
+      </button>
+    </th>
+  );
+}
+
+function DirChevron({ dir }: { dir: SortDir }) {
+  return dir === "asc" ? <ChevronUp className="size-3" aria-hidden /> : <ChevronDown className="size-3" aria-hidden />;
+}
+
+function RankBadge({ rank }: { rank: number }) {
+  if (rank === 1) return <Crown className="mx-auto size-4 text-page-accent-strong" aria-hidden />;
+  return <span className="font-mono text-xs font-semibold text-muted-foreground">{rank}</span>;
+}
+
+function MemberCell({ entry, isMe, youLabel }: { entry: BoardSummaryEntry; isMe: boolean; youLabel: string }) {
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <Avatar className="size-6 border border-border">
+        <AvatarFallback className="bg-card text-2xs font-semibold text-foreground">
+          {getInitials(entry.member.username, entry.member.first_name ?? undefined, entry.member.last_name ?? undefined) || (
+            <User className="size-3 text-muted-foreground" aria-hidden />
+          )}
+        </AvatarFallback>
+      </Avatar>
+      <span className="min-w-0 truncate font-medium">{displayName(entry.member.username, entry.member.first_name, entry.member.last_name)}</span>
+      {isMe ? <span className="shrink-0 rounded-md bg-page-accent p-1 text-2xs font-medium uppercase tracking-wide text-white">{youLabel}</span> : null}
+    </span>
+  );
+}

--- a/src/features/competitions/components/CompetitionCard.tsx
+++ b/src/features/competitions/components/CompetitionCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ListOrdered, MoreVertical, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import type { AwardType } from "@/features/awards/types/awards.types";
 import type { PickemProgress } from "@/features/pickems/types/pickems.types";
 import { useNow } from "@/features/schedule/hooks/useNow";
 import type { Match } from "@/features/schedule/types/schedule.types";
@@ -25,6 +26,7 @@ import { DeleteCompetitionDialog } from "./DeleteCompetitionDialog";
 import { PicksCta } from "./PicksCta";
 
 type PickemContext = { progress: PickemProgress | null; isLocked: boolean };
+type AwardsContext = { pickedTypes: AwardType[]; isLocked: boolean };
 
 type Props = {
   boardId: number;
@@ -35,10 +37,22 @@ type Props = {
   teamsByCode: Map<string, Team>;
   topThree: LeaderboardEntry[];
   pickemContext?: PickemContext;
+  awardsContext?: AwardsContext;
   canManage: boolean;
 };
 
-export function CompetitionCard({ boardId, competition, currentUserId, currentUserInitials, matches, teamsByCode, topThree, pickemContext, canManage }: Props) {
+export function CompetitionCard({
+  boardId,
+  competition,
+  currentUserId,
+  currentUserInitials,
+  matches,
+  teamsByCode,
+  topThree,
+  pickemContext,
+  awardsContext,
+  canManage,
+}: Props) {
   const t = useTranslations("competitions.card");
   const tRoot = useTranslations("competitions");
   const competitionName = useCompetitionName();
@@ -47,9 +61,9 @@ export function CompetitionCard({ boardId, competition, currentUserId, currentUs
 
   const meta = competitionTypeMeta(competition.type);
   const Icon = meta.icon;
-  const pickState = getCompetitionPickState(competition, matches, now, pickemContext);
+  const pickState = getCompetitionPickState(competition, matches, now, pickemContext, awardsContext);
   const needsPick = competitionNeedsPick(pickState);
-  const deletable = canManage && competition.type !== "pickem";
+  const deletable = canManage;
   const picksHref = competitionDeepLink(competition, pickState);
 
   return (
@@ -92,6 +106,7 @@ export function CompetitionCard({ boardId, competition, currentUserId, currentUs
         teamsByCode={teamsByCode}
         pickState={pickState}
         pickemProgress={pickemContext?.progress ?? null}
+        awardsPickedTypes={awardsContext?.pickedTypes ?? []}
         now={now}
       />
 

--- a/src/features/competitions/components/CompetitionCardContext.tsx
+++ b/src/features/competitions/components/CompetitionCardContext.tsx
@@ -4,6 +4,8 @@ import { CalendarDays, Crosshair, Flag, LayoutGrid, Medal, Network } from "lucid
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 
+import { AWARD_CONFIG, AWARD_TYPES } from "@/features/awards/lib/awards";
+import type { AwardType } from "@/features/awards/types/awards.types";
 import type { PickemProgress, StepProgress } from "@/features/pickems/types/pickems.types";
 import type { Match } from "@/features/schedule/types/schedule.types";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/components/ui/tooltip";
@@ -14,7 +16,7 @@ import type { StageCode, Team } from "@/shared/types/wcp.types";
 
 import type { CompetitionPickState } from "../lib/competitionPickStatus";
 import { ALL_STAGES, resolveScope } from "../lib/formatScope";
-import { resolvePoolMatch } from "../lib/resolvePoolMatch";
+import { resolvePickMatch } from "../lib/resolvePickMatch";
 import type { Competition } from "../types/competitions.types";
 
 import { CompetitionCountdown } from "./CompetitionCountdown";
@@ -51,17 +53,46 @@ type Props = {
   teamsByCode: Map<string, Team>;
   pickState: CompetitionPickState;
   pickemProgress: PickemProgress | null;
+  awardsPickedTypes: AwardType[];
   now: Date;
 };
 
-export function CompetitionCardContext({ competition, matches, teamsByCode, pickState, pickemProgress, now }: Props) {
-  if (competition.type === "pool") {
-    return <PoolContext competition={competition} matches={matches} pickState={pickState} now={now} />;
+export function CompetitionCardContext({ competition, matches, teamsByCode, pickState, pickemProgress, awardsPickedTypes, now }: Props) {
+  if (competition.type === "pick") {
+    return <PickContext competition={competition} matches={matches} pickState={pickState} now={now} />;
   }
   if (competition.type === "pickem" && pickemProgress) {
     return <PickemContext progress={pickemProgress} pickState={pickState} now={now} />;
   }
+  if (competition.type === "awards") {
+    return <AwardsContext pickedTypes={awardsPickedTypes} pickState={pickState} now={now} />;
+  }
   return <ScopeContext competition={competition} teamsByCode={teamsByCode} pickState={pickState} now={now} />;
+}
+
+// awards: the four individual honors — each tile reads accent once that honor is picked, muted otherwise.
+function AwardsContext({ pickedTypes, pickState, now }: { pickedTypes: AwardType[]; pickState: CompetitionPickState; now: Date }) {
+  const t = useTranslations("competitions.card");
+  const tTypes = useTranslations("awards.types");
+  const picked = new Set(pickedTypes);
+
+  return (
+    <div className={CONTEXT_BOX}>
+      <ContextHeader label={t("awards.label")} pickState={pickState} now={now} />
+      <div className="grid flex-1 grid-cols-2 gap-1.5">
+        {AWARD_TYPES.map((type) => {
+          const Icon = AWARD_CONFIG[type].icon;
+          const isPicked = picked.has(type);
+          return (
+            <div key={type} className={cn("flex items-center gap-1.5 rounded-md bg-card px-2.5 py-2 ring-1 ring-foreground/5", isPicked && "ring-page-accent/30")}>
+              <Icon className={cn("size-3.5 shrink-0", isPicked ? "text-page-accent-strong" : "text-muted-foreground")} aria-hidden />
+              <span className={cn("truncate text-2xs font-medium", isPicked ? "text-foreground" : "text-muted-foreground")}>{tTypes(`${type}.title`)}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 // pick'em: the viewer's progress through the three predicting steps — useful, actionable info.
@@ -196,12 +227,12 @@ function StageChipStack({ stages, max = 4 }: { stages: StageCode[]; max?: number
   );
 }
 
-// pool: a compact schedule-style card for the single covered match.
-function PoolContext({ competition, matches, pickState, now }: { competition: Competition; matches: Match[]; pickState: CompetitionPickState; now: Date }) {
+// pick: a compact schedule-style card for the single covered match.
+function PickContext({ competition, matches, pickState, now }: { competition: Competition; matches: Match[]; pickState: CompetitionPickState; now: Date }) {
   const locale = useLocale();
   const tStages = useTranslations("schedule.filters.stage");
   const t = useTranslations("competitions.card");
-  const match = resolvePoolMatch(competition, matches);
+  const match = resolvePickMatch(competition, matches);
 
   if (!match) {
     return <div className={cn(CONTEXT_BOX, "items-center text-center text-xs text-muted-foreground")}>{t("matchUnavailable")}</div>;
@@ -216,9 +247,9 @@ function PoolContext({ competition, matches, pickState, now }: { competition: Co
       <ContextHeader label={tStages(match.stage_code)} pickState={pickState} now={now} />
 
       <div className="flex items-center gap-2">
-        <PoolTeam team={home} locale={locale} side="home" />
+        <PickTeam team={home} locale={locale} side="home" />
         <span className="shrink-0 text-sm font-semibold text-muted-foreground">{result ? `${result.home_score}–${result.away_score}` : t("vs")}</span>
-        <PoolTeam team={away} locale={locale} side="away" />
+        <PickTeam team={away} locale={locale} side="away" />
       </div>
 
       <div className="flex items-center justify-between gap-2 border-t border-border/60 pt-2 text-2xs text-muted-foreground">
@@ -232,8 +263,8 @@ function PoolContext({ competition, matches, pickState, now }: { competition: Co
   );
 }
 
-// One side of a pool match, schedule-style: flag on the outer edge, name + FIFA code on the inner.
-function PoolTeam({ team, locale, side }: { team: Team | null; locale: string; side: "home" | "away" }) {
+// One side of a pick match, schedule-style: flag on the outer edge, name + FIFA code on the inner.
+function PickTeam({ team, locale, side }: { team: Team | null; locale: string; side: "home" | "away" }) {
   const flag = (
     <span className="shrink-0 overflow-hidden rounded-xs ring-1 ring-foreground/10">
       {team?.flag_url ? (

--- a/src/features/competitions/components/CompetitionDetailHeader.tsx
+++ b/src/features/competitions/components/CompetitionDetailHeader.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { CalendarDays, Clock, Crosshair, Flag, Hash, Star } from "lucide-react";
+import { Award, CalendarDays, Clock, Crosshair, Flag, Hash, Star } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
+import { AWARD_TYPES } from "@/features/awards/lib/awards";
+import type { AwardType } from "@/features/awards/types/awards.types";
 import type { PickemProgress } from "@/features/pickems/types/pickems.types";
 import { useNow } from "@/features/schedule/hooks/useNow";
 import type { Match } from "@/features/schedule/types/schedule.types";
@@ -15,7 +17,7 @@ import { competitionDeepLink } from "../lib/competitionDeepLink";
 import { getCompetitionPickState } from "../lib/competitionPickStatus";
 import { competitionTypeMeta } from "../lib/competitionTypeMeta";
 import { resolveScope } from "../lib/formatScope";
-import { resolvePoolMatch } from "../lib/resolvePoolMatch";
+import { resolvePickMatch } from "../lib/resolvePickMatch";
 import type { Competition } from "../types/competitions.types";
 
 import { CompetitionCountdown } from "./CompetitionCountdown";
@@ -25,9 +27,10 @@ type Props = {
   competition: Competition;
   matches: Match[];
   pickem: { progress: PickemProgress | null; isLocked: boolean } | null;
+  awards: { pickedTypes: AwardType[]; isLocked: boolean } | null;
 };
 
-export function CompetitionDetailHeader({ competition, matches, pickem }: Props) {
+export function CompetitionDetailHeader({ competition, matches, pickem, awards }: Props) {
   const t = useTranslations("competitions");
   const tInfo = useTranslations("competitions.info");
   const competitionName = useCompetitionName();
@@ -35,9 +38,9 @@ export function CompetitionDetailHeader({ competition, matches, pickem }: Props)
 
   const meta = competitionTypeMeta(competition.type);
   const Icon = meta.icon;
-  const pickState = getCompetitionPickState(competition, matches, now, pickem ?? undefined);
+  const pickState = getCompetitionPickState(competition, matches, now, pickem ?? undefined, awards ?? undefined);
   const picksHref = competitionDeepLink(competition, pickState);
-  const poolMatch = competition.type === "pool" ? resolvePoolMatch(competition, matches) : null;
+  const pickMatch = competition.type === "pick" ? resolvePickMatch(competition, matches) : null;
 
   return (
     <div className="flex flex-col gap-4 border-b border-border pb-5 lg:flex-row lg:items-center lg:justify-between lg:gap-6">
@@ -54,7 +57,7 @@ export function CompetitionDetailHeader({ competition, matches, pickem }: Props)
             </div>
           </div>
         </div>
-        {poolMatch ? <PoolMeta match={poolMatch} /> : null}
+        {pickMatch ? <PickMeta match={pickMatch} /> : null}
       </div>
 
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-5">
@@ -89,8 +92,8 @@ function ScopeLine({ competition, matches }: { competition: Competition; matches
   const tInfo = useTranslations("competitions.info");
   const locale = useLocale();
 
-  if (competition.type === "pool") {
-    const match = resolvePoolMatch(competition, matches);
+  if (competition.type === "pick") {
+    const match = resolvePickMatch(competition, matches);
     if (!match) return null;
     const { home, away } = match.teams;
     return (
@@ -98,6 +101,17 @@ function ScopeLine({ competition, matches }: { competition: Competition; matches
         {home ? getTeamName(home, locale) : "—"}
         <span className="text-muted-foreground"> vs </span>
         {away ? getTeamName(away, locale) : "—"}
+      </span>
+    );
+  }
+
+  if (competition.type === "awards") {
+    return (
+      <span className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1">
+          <Award className="size-3.5" aria-hidden />
+          {tInfo("awardsCount", { count: AWARD_TYPES.length })}
+        </span>
       </span>
     );
   }
@@ -119,9 +133,9 @@ function ScopeLine({ competition, matches }: { competition: Competition; matches
   );
 }
 
-// Pool match date · time · stage as muted chips. Full width and spaced apart on mobile (it sits
+// Pick match date · time · stage as muted chips. Full width and spaced apart on mobile (it sits
 // outside the icon-indented column); natural width on larger screens.
-function PoolMeta({ match }: { match: Match }) {
+function PickMeta({ match }: { match: Match }) {
   const locale = useLocale();
   const tStages = useTranslations("schedule.filters.stage");
   const kickoff = new Date(match.kickoff_at);

--- a/src/features/competitions/components/CompetitionDetailView.tsx
+++ b/src/features/competitions/components/CompetitionDetailView.tsx
@@ -3,6 +3,7 @@
 import { ChevronLeft } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import type { AwardType } from "@/features/awards/types/awards.types";
 import type { Board } from "@/features/boards/types/boards.types";
 import type { PickemProgress } from "@/features/pickems/types/pickems.types";
 import type { Match } from "@/features/schedule/types/schedule.types";
@@ -20,10 +21,11 @@ type Props = {
   competition: Competition;
   matches: Match[];
   pickem: { progress: PickemProgress | null; isLocked: boolean } | null;
+  awards: { pickedTypes: AwardType[]; isLocked: boolean } | null;
   initialLeaderboard: LeaderboardPage | null;
 };
 
-export function CompetitionDetailView({ currentUserId, board, competition, matches, pickem, initialLeaderboard }: Props) {
+export function CompetitionDetailView({ currentUserId, board, competition, matches, pickem, awards, initialLeaderboard }: Props) {
   const t = useTranslations("competitions");
   const playersCount = initialLeaderboard?.total ?? 0;
 
@@ -37,7 +39,7 @@ export function CompetitionDetailView({ currentUserId, board, competition, match
         {t("detail.back")}
       </Link>
 
-      <CompetitionDetailHeader competition={competition} matches={matches} pickem={pickem} />
+      <CompetitionDetailHeader competition={competition} matches={matches} pickem={pickem} awards={awards} />
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <span className="text-sm text-muted-foreground">{t("leaderboard.memberCount", { count: playersCount })}</span>

--- a/src/features/competitions/components/CompetitionsTab.tsx
+++ b/src/features/competitions/components/CompetitionsTab.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { Flame, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import type { AwardType } from "@/features/awards/types/awards.types";
 import type { PickemProgress } from "@/features/pickems/types/pickems.types";
 import { useNow } from "@/features/schedule/hooks/useNow";
 import type { Match } from "@/features/schedule/types/schedule.types";
@@ -26,6 +27,7 @@ type Props = {
   teamsByCode: Map<string, Team>;
   topThreeByCompetition: Record<number, LeaderboardEntry[]>;
   pickemContext: { progress: PickemProgress | null; isLocked: boolean };
+  awardsContext: { pickedTypes: AwardType[]; isLocked: boolean };
   query: string;
   canManage: boolean;
   canCreate: boolean;
@@ -41,6 +43,7 @@ export function CompetitionsTab({
   teamsByCode,
   topThreeByCompetition,
   pickemContext,
+  awardsContext,
   query,
   canManage,
   canCreate,
@@ -57,8 +60,11 @@ export function CompetitionsTab({
   }, [competitions, query, competitionName]);
 
   const pendingCount = useMemo(
-    () => competitions.filter((c) => competitionNeedsPick(getCompetitionPickState(c, matches, now, c.type === "pickem" ? pickemContext : undefined))).length,
-    [competitions, matches, now, pickemContext]
+    () =>
+      competitions.filter((c) =>
+        competitionNeedsPick(getCompetitionPickState(c, matches, now, c.type === "pickem" ? pickemContext : undefined, c.type === "awards" ? awardsContext : undefined))
+      ).length,
+    [competitions, matches, now, pickemContext, awardsContext]
   );
 
   if (competitions.length === 0) {
@@ -84,6 +90,7 @@ export function CompetitionsTab({
             teamsByCode={teamsByCode}
             topThree={topThreeByCompetition[competition.id] ?? []}
             pickemContext={competition.type === "pickem" ? pickemContext : undefined}
+            awardsContext={competition.type === "awards" ? awardsContext : undefined}
             canManage={canManage}
           />
         ))}

--- a/src/features/competitions/components/CreateCompetitionWizard.tsx
+++ b/src/features/competitions/components/CreateCompetitionWizard.tsx
@@ -21,20 +21,27 @@ import type { GroupCode, StageCode, Team } from "@/shared/types/wcp.types";
 import { useCreateCompetition } from "../hooks/useCreateCompetition";
 import { competitionTypeMeta } from "../lib/competitionTypeMeta";
 import { ALL_STAGES } from "../lib/formatScope";
+import type { CompetitionType } from "../types/competitions.types";
 
-import { PoolMatchPicker } from "./PoolMatchPicker";
+import { PickMatchPicker } from "./PickMatchPicker";
 
 const NAME_MAX = 20;
-type CompetitionKind = "match" | "pool";
+type CompetitionKind = "match" | "pick" | "pickem" | "awards";
 type StepKey = "details" | "scope" | "match" | "summary";
 
 // Step 1 picks the type and names it; the second step branches by type. Custom is the default path
 // so the full stepper is visible before a type is chosen.
 const STEPS_BY_KIND: Record<CompetitionKind, StepKey[]> = {
   match: ["details", "scope", "summary"],
-  pool: ["details", "match", "summary"],
+  pick: ["details", "match", "summary"],
+  pickem: ["details", "summary"],
+  awards: ["details", "summary"],
 };
 const DEFAULT_STEPS: StepKey[] = ["details", "scope", "summary"];
+
+type SingletonKind = "pickem" | "awards";
+const SINGLETON_NAME: Record<SingletonKind, string> = { pickem: "Pick'em", awards: "Awards" };
+const isSingleton = (kind: CompetitionKind | null): kind is SingletonKind => kind === "pickem" || kind === "awards";
 
 type Props = {
   open: boolean;
@@ -42,9 +49,10 @@ type Props = {
   boardId: number;
   teams: Team[];
   matches: Match[];
+  existingTypes: CompetitionType[];
 };
 
-export function CreateCompetitionWizard({ open, onOpenChange, boardId, teams, matches }: Props) {
+export function CreateCompetitionWizard({ open, onOpenChange, boardId, teams, matches, existingTypes }: Props) {
   const t = useTranslations("competitions.create");
   const tRoot = useTranslations("competitions");
   const tStages = useTranslations("schedule.filters.stage");
@@ -60,7 +68,7 @@ export function CreateCompetitionWizard({ open, onOpenChange, boardId, teams, ma
   const [name, setName] = useState("");
   const [stages, setStages] = useState<StageCode[]>([]);
   const [teamCodes, setTeamCodes] = useState<string[]>([]);
-  const [poolMatchId, setPoolMatchId] = useState<number | null>(null);
+  const [pickMatchId, setPickMatchId] = useState<number | null>(null);
   const focus = useAutoFocusUnlessMobile();
 
   const steps = kind ? STEPS_BY_KIND[kind] : DEFAULT_STEPS;
@@ -68,17 +76,16 @@ export function CreateCompetitionWizard({ open, onOpenChange, boardId, teams, ma
   const trimmed = name.trim();
   const isNameValid = trimmed.length > 0 && trimmed.length <= NAME_MAX;
   const isScopeValid = stages.length > 0 && teamCodes.length > 0;
-  const isMatchValid = poolMatchId !== null;
-  const isBranchValid = kind === "pool" ? isMatchValid : isScopeValid;
+  const isMatchValid = pickMatchId !== null;
+  const isBranchValid = kind === "pick" ? isMatchValid : kind === "match" ? isScopeValid : true;
   const isAllTeams = teamCodes.length === allTeamCodes.length;
   const isAllStages = stages.length === ALL_STAGES.length;
 
-  // Pools are named automatically from the picked match (FIFA codes keep it within the 20-char cap),
-  // so the name field is skipped for them and the details step only needs a type.
-  const poolMatch = poolMatchId != null ? matches.find((m) => m.id === poolMatchId) : undefined;
-  const poolName = poolMatch ? `${poolMatch.teams.home?.fifa_code ?? "?"} vs ${poolMatch.teams.away?.fifa_code ?? "?"}` : "";
-  const resolvedName = kind === "pool" ? poolName : trimmed;
-  const isDetailsValid = kind !== null && (kind === "pool" || isNameValid);
+  const pickMatch = pickMatchId != null ? matches.find((m) => m.id === pickMatchId) : undefined;
+  const pickName = pickMatch ? `${pickMatch.teams.home?.fifa_code ?? "?"} vs ${pickMatch.teams.away?.fifa_code ?? "?"}` : "";
+  const resolvedName = kind === "pick" ? pickName : isSingleton(kind) ? SINGLETON_NAME[kind] : trimmed;
+  const isDetailsValid = kind !== null && (kind === "pick" || isSingleton(kind) || isNameValid);
+  const nameFixed = kind === "pick" || isSingleton(kind);
 
   const teamsByGroup = useMemo(() => {
     const groups = new Map<GroupCode | "_", Team[]>();
@@ -96,7 +103,7 @@ export function CreateCompetitionWizard({ open, onOpenChange, boardId, teams, ma
     setName("");
     setStages([]);
     setTeamCodes([]);
-    setPoolMatchId(null);
+    setPickMatchId(null);
   }
 
   function close() {
@@ -148,9 +155,13 @@ export function CreateCompetitionWizard({ open, onOpenChange, boardId, teams, ma
 
   async function submit() {
     const input =
-      kind === "pool"
-        ? ({ name: resolvedName, type: "pool", match_id: poolMatchId! } as const)
-        : ({ name: resolvedName, type: "match", scope: { stages, team_fifa_codes: isAllTeams ? [] : teamCodes } } as const);
+      kind === "pick"
+        ? ({ name: resolvedName, type: "pick", match_id: pickMatchId! } as const)
+        : kind === "pickem"
+          ? ({ name: resolvedName, type: "pickem" } as const)
+          : kind === "awards"
+            ? ({ name: resolvedName, type: "awards" } as const)
+            : ({ name: resolvedName, type: "match", scope: { stages, team_fifa_codes: isAllTeams ? [] : teamCodes } } as const);
 
     const created = await mutation.mutateAsync(input).catch((error: Error) => {
       toast.error(translateApiError(error, tApiErrors));
@@ -187,13 +198,31 @@ export function CreateCompetitionWizard({ open, onOpenChange, boardId, teams, ma
                     description={t("type.customDescription")}
                     onClick={() => setKind("match")}
                   />
-                  <TypeCard type="pool" active={kind === "pool"} title={tRoot("type.pool")} description={t("type.poolDescription")} onClick={() => setKind("pool")} />
+                  <TypeCard type="pick" active={kind === "pick"} title={tRoot("type.pick")} description={t("type.pickDescription")} onClick={() => setKind("pick")} />
+                  {!existingTypes.includes("pickem") ? (
+                    <TypeCard
+                      type="pickem"
+                      active={kind === "pickem"}
+                      title={tRoot("type.pickem")}
+                      description={t("type.pickemDescription")}
+                      onClick={() => setKind("pickem")}
+                    />
+                  ) : null}
+                  {!existingTypes.includes("awards") ? (
+                    <TypeCard
+                      type="awards"
+                      active={kind === "awards"}
+                      title={tRoot("type.awards")}
+                      description={t("type.awardsDescription")}
+                      onClick={() => setKind("awards")}
+                    />
+                  ) : null}
                 </div>
               </div>
               <Field>
                 <FieldLabel htmlFor="comp-name">{t("name.label")}</FieldLabel>
-                {kind === "pool" ? (
-                  <Input id="comp-name" value={poolName} disabled placeholder={t("name.poolPlaceholder")} />
+                {nameFixed ? (
+                  <Input id="comp-name" value={resolvedName} disabled placeholder={t("name.pickPlaceholder")} />
                 ) : (
                   <Input
                     id="comp-name"
@@ -204,12 +233,12 @@ export function CreateCompetitionWizard({ open, onOpenChange, boardId, teams, ma
                     className="focus-visible:border-page-accent-strong focus-visible:ring-page-accent-strong/30"
                   />
                 )}
-                <FieldDescription>{kind === "pool" ? t("name.poolHelper") : t("name.helper")}</FieldDescription>
+                <FieldDescription>{kind === "pick" ? t("name.pickHelper") : isSingleton(kind) ? t("name.fixedHelper") : t("name.helper")}</FieldDescription>
               </Field>
             </div>
           ) : null}
 
-          {step === "match" ? <PoolMatchPicker matches={matches} value={poolMatchId} onChange={setPoolMatchId} /> : null}
+          {step === "match" ? <PickMatchPicker matches={matches} value={pickMatchId} onChange={setPickMatchId} /> : null}
 
           {step === "scope" ? (
             <div className="flex flex-col gap-4">
@@ -284,12 +313,12 @@ export function CreateCompetitionWizard({ open, onOpenChange, boardId, teams, ma
             <div className="flex flex-col gap-3 rounded-lg border bg-muted/30 p-4 text-sm">
               <SummaryRow label={t("summary.type")} value={kind ? tRoot(`type.${kind}`) : ""} />
               <SummaryRow label={t("summary.name")} value={resolvedName} />
-              {kind === "pool" ? (
+              {kind === "pick" ? (
                 <SummaryRow
                   label={t("summary.match")}
-                  value={poolMatch ? `${teamLabel(poolMatch.teams.home, locale)} ${t("match.vs")} ${teamLabel(poolMatch.teams.away, locale)}` : ""}
+                  value={pickMatch ? `${teamLabel(pickMatch.teams.home, locale)} ${t("match.vs")} ${teamLabel(pickMatch.teams.away, locale)}` : ""}
                 />
-              ) : (
+              ) : isSingleton(kind) ? null : (
                 <>
                   <SummaryRow
                     label={t("summary.stages")}
@@ -334,15 +363,17 @@ function TypeCard({ type, active, title, description, onClick }: { type: Competi
       onClick={onClick}
       aria-pressed={active}
       className={cn(
-        "flex flex-col gap-2 rounded-xl border bg-card p-4 text-left transition-colors hover:bg-muted",
+        "flex items-center gap-3 rounded-xl border bg-card p-3 text-left transition-colors hover:bg-muted sm:flex-col sm:items-start sm:gap-2 sm:p-4",
         active ? "border-page-accent ring-1 ring-page-accent/20" : "border-border"
       )}
     >
-      <span className={cn("grid size-10 place-items-center rounded-lg", meta.tileClass)}>
+      <span className={cn("grid size-10 shrink-0 place-items-center rounded-lg", meta.tileClass)}>
         <Icon className="size-5" aria-hidden />
       </span>
-      <span className="font-heading text-base font-semibold">{title}</span>
-      <span className="text-xs text-muted-foreground">{description}</span>
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-heading text-base font-semibold">{title}</span>
+        <span className="text-xs text-muted-foreground">{description}</span>
+      </span>
     </button>
   );
 }

--- a/src/features/competitions/components/DeleteCompetitionDialog.tsx
+++ b/src/features/competitions/components/DeleteCompetitionDialog.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
+import { ConfirmByTyping } from "@/shared/components/ConfirmByTyping";
 import { Button } from "@/shared/components/ui/button";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
+import { useAutoFocusUnlessMobile } from "@/shared/hooks/useAutoFocusUnlessMobile";
 import { translateApiError } from "@/shared/lib/api/errors";
 
 import { useCompetitionName } from "../hooks/useCompetitionName";
@@ -25,6 +28,10 @@ export function DeleteCompetitionDialog({ boardId, competition, open, onOpenChan
   const competitionName = useCompetitionName();
   const router = useRouter();
   const mutation = useDeleteCompetition(boardId);
+  const focus = useAutoFocusUnlessMobile();
+  const [typed, setTyped] = useState("");
+
+  const name = competitionName(competition.name);
 
   async function handleConfirm() {
     await mutation.mutateAsync(competition.id).then(
@@ -38,17 +45,38 @@ export function DeleteCompetitionDialog({ boardId, competition, open, onOpenChan
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setTyped("");
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent onOpenAutoFocus={focus.onOpenAutoFocus}>
         <DialogHeader>
-          <DialogTitle>{t("title")}</DialogTitle>
-          <DialogDescription>{t("description", { name: competitionName(competition.name) })}</DialogDescription>
+          <DialogTitle>{t("title", { name })}</DialogTitle>
         </DialogHeader>
+        <ConfirmByTyping
+          inputId="delete-competition-confirm"
+          warning={t("description", { name })}
+          label={t.rich("typeToConfirm", { name, b: (chunks) => <span className="font-medium text-foreground">{chunks}</span> })}
+          placeholder={name}
+          value={typed}
+          onChange={setTyped}
+          autoFocus={focus.autoFocus}
+        />
         <DialogFooter className="flex-col sm:flex-row-reverse sm:justify-start">
-          <Button variant="destructive" onClick={handleConfirm} disabled={mutation.isPending}>
+          <Button variant="destructive" onClick={handleConfirm} disabled={typed !== name || mutation.isPending}>
             {t("confirm")}
           </Button>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={mutation.isPending}>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setTyped("");
+              onOpenChange(false);
+            }}
+            disabled={mutation.isPending}
+          >
             {t("cancel")}
           </Button>
         </DialogFooter>

--- a/src/features/competitions/components/LeaderboardMobileTable.tsx
+++ b/src/features/competitions/components/LeaderboardMobileTable.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/shared/components/ui/button";
@@ -19,44 +18,53 @@ type Props = {
   currentUserId: string;
   isLoading: boolean;
   emptyLabel: string;
+  sort: string;
+  dir: "asc" | "desc";
+  onSort: (key: string) => void;
 };
 
-export function LeaderboardMobileTable({ rows, cyclableColumns, currentUserId, isLoading, emptyLabel }: Props) {
+// The cycler picks which metric to show AND sorts by it; tapping the active
+// column label flips the direction.
+export function LeaderboardMobileTable({ rows, cyclableColumns, currentUserId, isLoading, emptyLabel, sort, dir, onSort }: Props) {
   const t = useTranslations("competitions.leaderboard");
   const tCols = useTranslations("competitions.leaderboard.columns");
-  const [activeColumn, setActiveColumn] = useState(0);
 
-  const active = cyclableColumns[activeColumn] ?? cyclableColumns[0];
-  const prevIdx = (activeColumn - 1 + cyclableColumns.length) % cyclableColumns.length;
-  const nextIdx = (activeColumn + 1) % cyclableColumns.length;
-  const prevLabel = cyclableColumns[prevIdx]?.labelKey ?? "";
-  const nextLabel = cyclableColumns[nextIdx]?.labelKey ?? "";
+  const activeIdx = Math.max(
+    0,
+    cyclableColumns.findIndex((c) => c.id === sort)
+  );
+  const active = cyclableColumns[activeIdx] ?? cyclableColumns[0];
+  const prev = cyclableColumns[(activeIdx - 1 + cyclableColumns.length) % cyclableColumns.length];
+  const next = cyclableColumns[(activeIdx + 1) % cyclableColumns.length];
 
   return (
     <div className="flex flex-col">
       <div className="grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b border-border px-2 pb-2 text-2xs font-medium uppercase tracking-wider text-muted-foreground">
         <span className="w-9">{t("columns.rank")}</span>
         <span>{t("columns.member")}</span>
-        <div className="flex w-24 items-center justify-between gap-0.5">
+        <div className="flex w-28 items-center justify-between gap-0.5">
           <Button
             type="button"
             variant="ghost"
             size="icon-sm"
-            onClick={() => setActiveColumn(prevIdx)}
+            onClick={() => onSort(prev.id)}
             disabled={cyclableColumns.length <= 1}
-            aria-label={t("mobile.prevColumn", { name: tCols(prevLabel) })}
+            aria-label={t("mobile.prevColumn", { name: tCols(prev.labelKey) })}
             className="size-6 shrink-0"
           >
             <ChevronLeft className="size-3.5" aria-hidden />
           </Button>
-          <span className="flex-1 text-center tabular-nums">{tCols(active.labelKey)}</span>
+          <button type="button" onClick={() => onSort(active.id)} className="flex flex-1 cursor-pointer items-center justify-center gap-0.5 tabular-nums text-foreground">
+            {tCols(active.labelKey)}
+            {dir === "asc" ? <ChevronUp className="size-3" aria-hidden /> : <ChevronDown className="size-3" aria-hidden />}
+          </button>
           <Button
             type="button"
             variant="ghost"
             size="icon-sm"
-            onClick={() => setActiveColumn(nextIdx)}
+            onClick={() => onSort(next.id)}
             disabled={cyclableColumns.length <= 1}
-            aria-label={t("mobile.nextColumn", { name: tCols(nextLabel) })}
+            aria-label={t("mobile.nextColumn", { name: tCols(next.labelKey) })}
             className="size-6 shrink-0"
           >
             <ChevronRight className="size-3.5" aria-hidden />
@@ -75,7 +83,7 @@ export function LeaderboardMobileTable({ rows, cyclableColumns, currentUserId, i
                 <Skeleton className="h-4 w-28" />
                 <Skeleton className="h-2.5 w-16" />
               </div>
-              <span className="flex w-24 justify-center">
+              <span className="flex w-28 justify-center">
                 <Skeleton className="h-4 w-10" />
               </span>
             </li>
@@ -99,7 +107,17 @@ export function LeaderboardMobileTable({ rows, cyclableColumns, currentUserId, i
                   </span>
                   <span className="truncate text-xs text-muted-foreground">@{entry.member.username}</span>
                 </div>
-                <span className="w-24 text-center text-base font-semibold tabular-nums">{active.value(entry).toLocaleString()}</span>
+                <span className="flex w-28 justify-center text-base font-semibold tabular-nums">
+                  {active.display === "check" ? (
+                    active.value(entry) === 1 ? (
+                      <Check className="size-4 text-lime-600 dark:text-lime-400" aria-hidden />
+                    ) : (
+                      <X className="size-4 text-muted-foreground/40" aria-hidden />
+                    )
+                  ) : (
+                    active.value(entry).toLocaleString()
+                  )}
+                </span>
               </li>
             );
           })}

--- a/src/features/competitions/components/LeaderboardSection.tsx
+++ b/src/features/competitions/components/LeaderboardSection.tsx
@@ -22,6 +22,8 @@ type Props = {
 
 const PAGE_PARAM = "page";
 const Q_PARAM = "q";
+const SORT_PARAM = "sort";
+const DIR_PARAM = "dir";
 
 export function LeaderboardSection({ boardId, competition, currentUserId, initialData }: Props) {
   const t = useTranslations("competitions.leaderboard");
@@ -31,6 +33,8 @@ export function LeaderboardSection({ boardId, competition, currentUserId, initia
 
   const page = Math.max(1, Number(searchParams.get(PAGE_PARAM) ?? "1") || 1);
   const query_ = searchParams.get(Q_PARAM)?.trim() ?? "";
+  const sort = searchParams.get(SORT_PARAM) ?? "total";
+  const dir = searchParams.get(DIR_PARAM) === "asc" ? "asc" : "desc";
 
   const columns = useMemo(() => buildColumns(competition.type), [competition.type]);
   const cyclableColumns = useMemo(() => buildMobileCyclableColumns(competition.type), [competition.type]);
@@ -40,6 +44,8 @@ export function LeaderboardSection({ boardId, competition, currentUserId, initia
     competitionId: competition.id,
     page,
     q: query_,
+    sort,
+    dir,
     initialData: initialData ?? undefined,
   });
 
@@ -59,13 +65,44 @@ export function LeaderboardSection({ boardId, competition, currentUserId, initia
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
   }
 
+  // Click a new column → sort it descending; click the active column → flip direction.
+  function onSort(key: string) {
+    const params = new URLSearchParams(searchParams);
+    const nextDir = key === sort && dir === "desc" ? "asc" : "desc";
+    if (key === "total") params.delete(SORT_PARAM);
+    else params.set(SORT_PARAM, key);
+    if (nextDir === "desc") params.delete(DIR_PARAM);
+    else params.set(DIR_PARAM, "asc");
+    params.delete(PAGE_PARAM);
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }
+
   return (
     <div className="overflow-hidden rounded-xl border border-foreground/10 bg-card shadow-xs">
       <div className="hidden md:block">
-        <LeaderboardTable columns={columns} rows={items} currentUserId={currentUserId} isLoading={isLoading} emptyLabel={emptyLabel} />
+        <LeaderboardTable
+          columns={columns}
+          rows={items}
+          currentUserId={currentUserId}
+          isLoading={isLoading}
+          emptyLabel={emptyLabel}
+          sort={sort}
+          dir={dir}
+          onSort={onSort}
+        />
       </div>
       <div className="p-4 md:hidden">
-        <LeaderboardMobileTable rows={items} cyclableColumns={cyclableColumns} currentUserId={currentUserId} isLoading={isLoading} emptyLabel={emptyLabel} />
+        <LeaderboardMobileTable
+          rows={items}
+          cyclableColumns={cyclableColumns}
+          currentUserId={currentUserId}
+          isLoading={isLoading}
+          emptyLabel={emptyLabel}
+          sort={sort}
+          dir={dir}
+          onSort={onSort}
+        />
       </div>
 
       {totalPages > 1 ? (

--- a/src/features/competitions/components/LeaderboardTable.tsx
+++ b/src/features/competitions/components/LeaderboardTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { Check, ChevronDown, ChevronsUpDown, ChevronUp, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Skeleton } from "@/shared/components/ui/skeleton";
@@ -16,9 +17,12 @@ type Props = {
   currentUserId: string;
   isLoading: boolean;
   emptyLabel: string;
+  sort: string;
+  dir: "asc" | "desc";
+  onSort: (key: string) => void;
 };
 
-export function LeaderboardTable({ columns, rows, currentUserId, isLoading, emptyLabel }: Props) {
+export function LeaderboardTable({ columns, rows, currentUserId, isLoading, emptyLabel, sort, dir, onSort }: Props) {
   const tCols = useTranslations("competitions.leaderboard.columns");
   const tColsLong = useTranslations("competitions.leaderboard.columnsLong");
 
@@ -41,10 +45,12 @@ export function LeaderboardTable({ columns, rows, currentUserId, isLoading, empt
               const meta = header.column.columnDef.meta;
               const headerKey = header.column.columnDef.header as string;
               const isNumeric = headerKey !== "rank" && headerKey !== "member";
+              const isActive = sort === headerKey;
               return (
                 <th
                   key={header.id}
                   title={isNumeric ? tColsLong(headerKey) : undefined}
+                  aria-sort={isActive ? (dir === "asc" ? "ascending" : "descending") : undefined}
                   className={cn(
                     "px-4 py-2.5 whitespace-nowrap",
                     meta?.align === "left" && "text-left",
@@ -53,7 +59,26 @@ export function LeaderboardTable({ columns, rows, currentUserId, isLoading, empt
                     meta?.width
                   )}
                 >
-                  {tCols(headerKey)}
+                  {isNumeric ? (
+                    <button
+                      type="button"
+                      onClick={() => onSort(headerKey)}
+                      className={cn("inline-flex cursor-pointer items-center gap-1 transition-colors hover:text-foreground", isActive && "text-foreground")}
+                    >
+                      {tCols(headerKey)}
+                      {isActive ? (
+                        dir === "asc" ? (
+                          <ChevronUp className="size-3" aria-hidden />
+                        ) : (
+                          <ChevronDown className="size-3" aria-hidden />
+                        )
+                      ) : (
+                        <ChevronsUpDown className="size-3 text-muted-foreground/50" aria-hidden />
+                      )}
+                    </button>
+                  ) : (
+                    tCols(headerKey)
+                  )}
                 </th>
               );
             })}
@@ -108,7 +133,13 @@ export function LeaderboardTable({ columns, rows, currentUserId, isLoading, empt
                         isMember && "font-medium"
                       )}
                     >
-                      {isMember ? <MemberCell entry={row.original} isMe={isMe} /> : flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      {isMember ? (
+                        <MemberCell entry={row.original} isMe={isMe} />
+                      ) : meta?.display === "check" ? (
+                        <CheckCell value={cell.getValue() as number} />
+                      ) : (
+                        flexRender(cell.column.columnDef.cell, cell.getContext())
+                      )}
                     </td>
                   );
                 })}
@@ -118,6 +149,14 @@ export function LeaderboardTable({ columns, rows, currentUserId, isLoading, empt
         )}
       </tbody>
     </table>
+  );
+}
+
+function CheckCell({ value }: { value: number }) {
+  return value === 1 ? (
+    <Check className="mx-auto size-4 text-lime-600 dark:text-lime-400" aria-hidden />
+  ) : (
+    <X className="mx-auto size-4 text-muted-foreground/40" aria-hidden />
   );
 }
 

--- a/src/features/competitions/components/PickMatchPicker.tsx
+++ b/src/features/competitions/components/PickMatchPicker.tsx
@@ -20,9 +20,9 @@ type Props = {
   onChange: (matchId: number) => void;
 };
 
-// Picks the single match a pool competition covers. Only still-open matches are selectable — a pool
+// Picks the single match a pick competition covers. Only still-open matches are selectable — a pick
 // on a locked match has nothing left to predict.
-export function PoolMatchPicker({ matches, value, onChange }: Props) {
+export function PickMatchPicker({ matches, value, onChange }: Props) {
   const t = useTranslations("competitions.create.match");
   const tStages = useTranslations("schedule.filters.stage");
   const locale = useLocale();
@@ -30,7 +30,7 @@ export function PoolMatchPicker({ matches, value, onChange }: Props) {
   const [search, setSearch] = useState("");
 
   const selectable = useMemo(() => {
-    // Only matches with a confirmed fixture (both teams known) and still open can be pooled.
+    // Only matches with a confirmed fixture (both teams known) and still open can be picked.
     const open = matches.filter((m) => m.teams.home != null && m.teams.away != null && !computeMatchUiState(m, now).isLocked);
     return open.sort((a, b) => new Date(a.kickoff_at).getTime() - new Date(b.kickoff_at).getTime());
   }, [matches, now]);

--- a/src/features/competitions/hooks/useBoardSummary.ts
+++ b/src/features/competitions/hooks/useBoardSummary.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { boardSummaryKey, fetchBoardSummary, LEADERBOARD_PAGE_SIZE } from "../api/competitions";
+
+type Params = {
+  boardId: number;
+  page: number;
+  q?: string;
+  sort?: string;
+  dir?: string;
+  enabled: boolean;
+};
+
+// Board-wide standings. Fetched only while the Resumen tab is open (enabled).
+export function useBoardSummary({ boardId, page, q, sort, dir, enabled }: Params) {
+  const normalizedQ = q ?? "";
+  const normalizedSort = sort ?? "total";
+  const normalizedDir = dir ?? "desc";
+  return useQuery({
+    queryKey: boardSummaryKey(boardId, { page, q: normalizedQ, sort: normalizedSort, dir: normalizedDir }),
+    queryFn: () => fetchBoardSummary(boardId, { page, limit: LEADERBOARD_PAGE_SIZE, q: normalizedQ, sort: normalizedSort, dir: normalizedDir }),
+    placeholderData: keepPreviousData,
+    enabled: enabled && Number.isFinite(boardId),
+  });
+}

--- a/src/features/competitions/hooks/useCompetitionName.ts
+++ b/src/features/competitions/hooks/useCompetitionName.ts
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { resolveCompetitionNameKey } from "../lib/competitionName";
 
 // Returns a resolver that localizes seeded default competition names (e.g. "All matches" →
-// "Full tournament" / "Torneo completo") while leaving user-created names as-is.
+// "Full schedule" / "Calendario completo") while leaving user-created names as-is.
 export function useCompetitionName() {
   const t = useTranslations("competitions.defaultNames");
   return (name: string) => {

--- a/src/features/competitions/hooks/useLeaderboard.ts
+++ b/src/features/competitions/hooks/useLeaderboard.ts
@@ -10,15 +10,21 @@ type Params = {
   competitionId: number;
   page: number;
   q?: string;
+  sort?: string;
+  dir?: string;
   initialData?: LeaderboardPage;
 };
 
-export function useLeaderboard({ boardId, competitionId, page, q, initialData }: Params) {
+export function useLeaderboard({ boardId, competitionId, page, q, sort, dir, initialData }: Params) {
   const normalizedQ = q ?? "";
+  const normalizedSort = sort ?? "total";
+  const normalizedDir = dir ?? "desc";
+  // The RSC seed is the default (total, desc) first page — only reuse it then.
+  const isDefault = page === 1 && normalizedQ === "" && normalizedSort === "total" && normalizedDir === "desc";
   return useQuery({
-    queryKey: leaderboardKey(boardId, competitionId, { page, q: normalizedQ }),
-    queryFn: () => fetchLeaderboard(boardId, competitionId, { page, limit: LEADERBOARD_PAGE_SIZE, q: normalizedQ }),
-    initialData: page === 1 && normalizedQ === "" ? initialData : undefined,
+    queryKey: leaderboardKey(boardId, competitionId, { page, q: normalizedQ, sort: normalizedSort, dir: normalizedDir }),
+    queryFn: () => fetchLeaderboard(boardId, competitionId, { page, limit: LEADERBOARD_PAGE_SIZE, q: normalizedQ, sort: normalizedSort, dir: normalizedDir }),
+    initialData: isDefault ? initialData : undefined,
     placeholderData: keepPreviousData,
     enabled: Number.isFinite(boardId) && Number.isFinite(competitionId),
   });

--- a/src/features/competitions/lib/competitionColumns.ts
+++ b/src/features/competitions/lib/competitionColumns.ts
@@ -91,9 +91,8 @@ const numericCol = (col: ValueColumn, emphasize = false): Column => ({
 });
 
 export function buildColumns(type: CompetitionType): Column[] {
-  // Total sits at the far right (after the breakdown columns) — the conventional
-  // place for a computed sum, matching the summary tab.
-  const valueCols = VALUE_COLUMNS_BY_TYPE[type];
+  // Total goes last (far right); fallback shape guards an unknown/legacy type.
+  const valueCols = VALUE_COLUMNS_BY_TYPE[type] ?? matchColumns;
   const ordered = [...valueCols.filter((col) => col.id !== "total"), ...valueCols.filter((col) => col.id === "total")];
   return [rank, member, ...ordered.map((col) => numericCol(col, col.id === "total"))];
 }
@@ -106,7 +105,7 @@ export type MobileCyclableColumn = {
 };
 
 export function buildMobileCyclableColumns(type: CompetitionType): MobileCyclableColumn[] {
-  return VALUE_COLUMNS_BY_TYPE[type].map((col) => ({
+  return (VALUE_COLUMNS_BY_TYPE[type] ?? matchColumns).map((col) => ({
     id: col.id,
     labelKey: col.id,
     value: col.value,

--- a/src/features/competitions/lib/competitionColumns.ts
+++ b/src/features/competitions/lib/competitionColumns.ts
@@ -2,14 +2,29 @@ import type { ColumnDef, RowData } from "@tanstack/react-table";
 
 import { displayName } from "@/shared/lib/ui";
 
-import type { CompetitionType, LeaderboardEntry, MatchScore, PickemScore } from "../types/competitions.types";
+import type { AwardsScore, CompetitionType, LeaderboardEntry, MatchScore, PickemScore } from "../types/competitions.types";
 
-export type LeaderboardColumnId = "rank" | "member" | "total" | "groupExact" | "groupQualifiers" | "bestThirds" | "bracket" | "exactHits" | "outcomes";
+export type LeaderboardColumnId =
+  | "rank"
+  | "member"
+  | "total"
+  | "groupExact"
+  | "groupQualifiers"
+  | "bestThirds"
+  | "bracket"
+  | "exactHits"
+  | "outcomes"
+  | "golden_boot"
+  | "golden_ball"
+  | "golden_glove"
+  | "young_player";
 
 export type LeaderboardColumnMeta = {
   align?: "left" | "right" | "center";
   width?: string;
   emphasize?: boolean;
+  // "check" renders the 0|1 value as a ✓/✗ instead of a number.
+  display?: "number" | "check";
 };
 
 declare module "@tanstack/react-table" {
@@ -21,10 +36,11 @@ type Column = ColumnDef<LeaderboardEntry>;
 
 const pickemScore = (row: LeaderboardEntry) => row.score as PickemScore;
 const matchScore = (row: LeaderboardEntry) => row.score as MatchScore;
+const awardsScore = (row: LeaderboardEntry) => row.score as AwardsScore;
 
-type ValueColumn = { id: LeaderboardColumnId; value: (row: LeaderboardEntry) => number };
+type ValueColumn = { id: LeaderboardColumnId; value: (row: LeaderboardEntry) => number; display?: "check" };
 
-// match and pool share the same scoring shape.
+// match and pick share the same scoring shape.
 const matchColumns: ValueColumn[] = [
   { id: "total", value: (row) => row.score.total },
   { id: "exactHits", value: (row) => matchScore(row).exact_hits },
@@ -40,7 +56,14 @@ const VALUE_COLUMNS_BY_TYPE: Record<CompetitionType, ValueColumn[]> = {
     { id: "bracket", value: (row) => pickemScore(row).bracket_hits },
   ],
   match: matchColumns,
-  pool: matchColumns,
+  pick: matchColumns,
+  awards: [
+    { id: "total", value: (row) => row.score.total },
+    { id: "golden_boot", value: (row) => awardsScore(row).golden_boot, display: "check" },
+    { id: "golden_ball", value: (row) => awardsScore(row).golden_ball, display: "check" },
+    { id: "golden_glove", value: (row) => awardsScore(row).golden_glove, display: "check" },
+    { id: "young_player", value: (row) => awardsScore(row).young_player, display: "check" },
+  ],
 };
 
 const rank: Column = {
@@ -59,23 +82,27 @@ const member: Column = {
   meta: { align: "left", width: "w-full" },
 };
 
-const numericCol = ({ id, value }: ValueColumn, emphasize = false): Column => ({
-  id,
-  accessorFn: value,
-  header: id,
+const numericCol = (col: ValueColumn, emphasize = false): Column => ({
+  id: col.id,
+  accessorFn: col.value,
+  header: col.id,
   cell: ({ getValue }) => (getValue() as number).toLocaleString(),
-  meta: { align: "center", emphasize, width: "w-20" },
+  meta: { align: "center", emphasize, width: col.display === "check" ? "w-14" : "w-20", display: col.display ?? "number" },
 });
 
 export function buildColumns(type: CompetitionType): Column[] {
+  // Total sits at the far right (after the breakdown columns) — the conventional
+  // place for a computed sum, matching the summary tab.
   const valueCols = VALUE_COLUMNS_BY_TYPE[type];
-  return [rank, member, ...valueCols.map((col) => numericCol(col, col.id === "total"))];
+  const ordered = [...valueCols.filter((col) => col.id !== "total"), ...valueCols.filter((col) => col.id === "total")];
+  return [rank, member, ...ordered.map((col) => numericCol(col, col.id === "total"))];
 }
 
 export type MobileCyclableColumn = {
   id: LeaderboardColumnId;
   labelKey: string;
   value: (row: LeaderboardEntry) => number;
+  display?: "check";
 };
 
 export function buildMobileCyclableColumns(type: CompetitionType): MobileCyclableColumn[] {
@@ -83,5 +110,6 @@ export function buildMobileCyclableColumns(type: CompetitionType): MobileCyclabl
     id: col.id,
     labelKey: col.id,
     value: col.value,
+    display: col.display,
   }));
 }

--- a/src/features/competitions/lib/competitionDeepLink.ts
+++ b/src/features/competitions/lib/competitionDeepLink.ts
@@ -8,8 +8,10 @@ export function competitionDeepLink(competition: Competition, pickState: Competi
   switch (competition.type) {
     case "pickem":
       return "/pickems";
-    case "pool":
-      return competition.pool_match_id != null ? `/schedule?match=${competition.pool_match_id}` : "/schedule";
+    case "awards":
+      return "/pickems/awards";
+    case "pick":
+      return competition.pick_match_id != null ? `/schedule?match=${competition.pick_match_id}` : "/schedule";
     default: {
       const matchId = pickState.kind === "needs-pick" ? pickState.matchId : undefined;
       return matchId != null ? `/schedule?match=${matchId}` : "/schedule";

--- a/src/features/competitions/lib/competitionName.ts
+++ b/src/features/competitions/lib/competitionName.ts
@@ -4,6 +4,7 @@
 // normalize casing so "All Matches"/"All matches"/"all matches" all resolve.
 const DEFAULT_NAME_KEYS: Record<string, string> = {
   "all matches": "fullTournament",
+  awards: "awards",
 };
 
 export function resolveCompetitionNameKey(name: string): string | null {

--- a/src/features/competitions/lib/competitionPickStatus.ts
+++ b/src/features/competitions/lib/competitionPickStatus.ts
@@ -1,3 +1,5 @@
+import { AWARD_TYPES } from "@/features/awards/lib/awards";
+import type { AwardType } from "@/features/awards/types/awards.types";
 import { isPickemComplete } from "@/features/pickems/lib/isPickemComplete";
 import type { PickemProgress } from "@/features/pickems/types/pickems.types";
 import { computeMatchUiState } from "@/features/schedule/lib/computeMatchUiState";
@@ -6,15 +8,17 @@ import type { Match } from "@/features/schedule/types/schedule.types";
 import type { Competition } from "../types/competitions.types";
 
 import { resolveScope } from "./formatScope";
-import { resolvePoolMatch } from "./resolvePoolMatch";
+import { resolvePickMatch } from "./resolvePickMatch";
 
 // Derived state of the viewer's picks for one competition, computed from already-fetched data — no
-// extra API calls. `none` is defensive: no in-scope matches resolved (e.g. a pool match not loaded).
+// extra API calls. `none` is defensive: no in-scope matches resolved (e.g. a pick match not loaded).
 export type CompetitionPickState = { kind: "needs-pick"; countdownTarget?: string; matchId?: number } | { kind: "picks-done" } | { kind: "closed" } | { kind: "none" };
 
 export const competitionNeedsPick = (state: CompetitionPickState): boolean => state.kind === "needs-pick";
 
-// Reduce a set of in-scope matches to a pick state. Shared by the match and pool variants.
+type AwardsContext = { pickedTypes: AwardType[]; isLocked: boolean };
+
+// Reduce a set of in-scope matches to a pick state. Shared by the match and pick variants.
 function fromMatches(matches: Match[], now: Date): CompetitionPickState {
   if (matches.length === 0) return { kind: "none" };
 
@@ -48,9 +52,9 @@ function getMatchCompetitionPickState(competition: Competition, matches: Match[]
   return fromMatches(inScope, now);
 }
 
-// A pool competition covers exactly one match.
-function getPoolCompetitionPickState(competition: Competition, matches: Match[], now: Date): CompetitionPickState {
-  const match = resolvePoolMatch(competition, matches);
+// A pick competition covers exactly one match.
+function getPickCompetitionPickState(competition: Competition, matches: Match[], now: Date): CompetitionPickState {
+  const match = resolvePickMatch(competition, matches);
   return fromMatches(match ? [match] : [], now);
 }
 
@@ -59,12 +63,22 @@ function getPoolCompetitionPickState(competition: Competition, matches: Match[],
 function getPickemPickState(progress: PickemProgress | null, isLocked: boolean, matches: Match[], now: Date): CompetitionPickState {
   if (progress && isPickemComplete(progress)) return { kind: "picks-done" };
   if (isLocked) return { kind: "closed" };
+  return { kind: "needs-pick", countdownTarget: nextKickoffAfter(matches, now) };
+}
+
+// Awards complete once all four honors are picked; the countdown mirrors pick'em (lock at kickoff).
+function getAwardsPickState(awards: AwardsContext, matches: Match[], now: Date): CompetitionPickState {
+  if (awards.pickedTypes.length >= AWARD_TYPES.length) return { kind: "picks-done" };
+  if (awards.isLocked) return { kind: "closed" };
+  return { kind: "needs-pick", countdownTarget: nextKickoffAfter(matches, now) };
+}
+
+function nextKickoffAfter(matches: Match[], now: Date): string | undefined {
   const nowMs = now.getTime();
-  const nextKickoff = matches
+  return matches
     .map((m) => m.kickoff_at)
     .filter((k) => new Date(k).getTime() > nowMs)
     .sort()[0];
-  return { kind: "needs-pick", countdownTarget: nextKickoff };
 }
 
 // Top-level dispatcher used by the card.
@@ -72,13 +86,16 @@ export function getCompetitionPickState(
   competition: Competition,
   matches: Match[],
   now: Date,
-  pickem?: { progress: PickemProgress | null; isLocked: boolean }
+  pickem?: { progress: PickemProgress | null; isLocked: boolean },
+  awards?: AwardsContext
 ): CompetitionPickState {
   switch (competition.type) {
-    case "pool":
-      return getPoolCompetitionPickState(competition, matches, now);
+    case "pick":
+      return getPickCompetitionPickState(competition, matches, now);
     case "pickem":
       return getPickemPickState(pickem?.progress ?? null, pickem?.isLocked ?? false, matches, now);
+    case "awards":
+      return awards ? getAwardsPickState(awards, matches, now) : { kind: "none" };
     default:
       return getMatchCompetitionPickState(competition, matches, now);
   }

--- a/src/features/competitions/lib/competitionPickStatus.ts
+++ b/src/features/competitions/lib/competitionPickStatus.ts
@@ -18,7 +18,6 @@ export const competitionNeedsPick = (state: CompetitionPickState): boolean => st
 
 type AwardsContext = { pickedTypes: AwardType[]; isLocked: boolean };
 
-// Reduce a set of in-scope matches to a pick state. Shared by the match and pick variants.
 function fromMatches(matches: Match[], now: Date): CompetitionPickState {
   if (matches.length === 0) return { kind: "none" };
 
@@ -28,7 +27,8 @@ function fromMatches(matches: Match[], now: Date): CompetitionPickState {
     const { isLocked, hasPick } = computeMatchUiState(match, now);
     if (isLocked) continue;
     anyOpen = true;
-    if (!hasPick && (!earliest || new Date(match.kickoff_at) < new Date(earliest.kickoff_at))) {
+    const isPickable = match.teams.home != null && match.teams.away != null;
+    if (isPickable && !hasPick && (!earliest || new Date(match.kickoff_at) < new Date(earliest.kickoff_at))) {
       earliest = match;
     }
   }

--- a/src/features/competitions/lib/competitionTypeMeta.ts
+++ b/src/features/competitions/lib/competitionTypeMeta.ts
@@ -1,4 +1,4 @@
-import { ListChecks, Swords, Trophy, type LucideIcon } from "lucide-react";
+import { Award, ListChecks, Swords, Trophy, type LucideIcon } from "lucide-react";
 
 import type { CompetitionType } from "../types/competitions.types";
 
@@ -12,7 +12,8 @@ type CompetitionTypeMeta = {
 const META: Record<CompetitionType, CompetitionTypeMeta> = {
   pickem: { icon: ListChecks, labelKey: "pickem", tileClass: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300" },
   match: { icon: Trophy, labelKey: "match", tileClass: "bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-300" },
-  pool: { icon: Swords, labelKey: "pool", tileClass: "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300" },
+  pick: { icon: Swords, labelKey: "pick", tileClass: "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300" },
+  awards: { icon: Award, labelKey: "awards", tileClass: "bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-300" },
 };
 
 export function competitionTypeMeta(type: CompetitionType): CompetitionTypeMeta {

--- a/src/features/competitions/lib/competitionTypeMeta.ts
+++ b/src/features/competitions/lib/competitionTypeMeta.ts
@@ -17,5 +17,6 @@ const META: Record<CompetitionType, CompetitionTypeMeta> = {
 };
 
 export function competitionTypeMeta(type: CompetitionType): CompetitionTypeMeta {
-  return META[type];
+  // Fallback so an unknown/legacy type can't crash the card on `meta.icon`.
+  return META[type] ?? META.match;
 }

--- a/src/features/competitions/lib/normalizeCompetition.ts
+++ b/src/features/competitions/lib/normalizeCompetition.ts
@@ -1,0 +1,14 @@
+import type { Competition, CompetitionType } from "../types/competitions.types";
+
+// Backward-compat shim for the `pool` -> `pick` rename: a stale/pre-migration API response can still
+// carry `type: "pool"`. Applied at every fetch boundary. Safe to delete once no `pool` rows remain.
+const LEGACY_TYPE: Record<string, CompetitionType> = { pool: "pick" };
+
+export function normalizeCompetitionType(type: string): CompetitionType {
+  return LEGACY_TYPE[type] ?? (type as CompetitionType);
+}
+
+export function normalizeCompetition(competition: Competition): Competition {
+  const type = normalizeCompetitionType(competition.type);
+  return type === competition.type ? competition : { ...competition, type };
+}

--- a/src/features/competitions/lib/resolvePickMatch.ts
+++ b/src/features/competitions/lib/resolvePickMatch.ts
@@ -1,0 +1,9 @@
+import type { Match } from "@/features/schedule/types/schedule.types";
+
+import type { Competition } from "../types/competitions.types";
+
+// The single match a `pick` competition covers, or null (non-pick, or the match isn't loaded).
+export function resolvePickMatch(competition: Competition, matches: Match[]): Match | null {
+  if (competition.pick_match_id == null) return null;
+  return matches.find((m) => m.id === competition.pick_match_id) ?? null;
+}

--- a/src/features/competitions/lib/resolvePoolMatch.ts
+++ b/src/features/competitions/lib/resolvePoolMatch.ts
@@ -1,9 +1,0 @@
-import type { Match } from "@/features/schedule/types/schedule.types";
-
-import type { Competition } from "../types/competitions.types";
-
-// The single match a `pool` competition covers, or null (non-pool, or the match isn't loaded).
-export function resolvePoolMatch(competition: Competition, matches: Match[]): Match | null {
-  if (competition.pool_match_id == null) return null;
-  return matches.find((m) => m.id === competition.pool_match_id) ?? null;
-}

--- a/src/features/competitions/types/competitions.types.ts
+++ b/src/features/competitions/types/competitions.types.ts
@@ -1,6 +1,6 @@
 import type { StageCode } from "@/shared/types/wcp.types";
 
-export type CompetitionType = "pickem" | "match" | "pool";
+export type CompetitionType = "pickem" | "match" | "pick" | "awards";
 
 export type CompetitionScope = {
   stages: StageCode[];
@@ -18,10 +18,12 @@ export type Competition = {
   type: CompetitionType;
   name: string;
   scope: CompetitionScope | null;
-  // Only set for `pool` competitions — the single match they cover.
-  pool_match_id: number | null;
+  // Only set for `pick` competitions — the single match they cover.
+  pick_match_id: number | null;
   created_at: string;
   viewer: CompetitionViewer;
+  // Top members previewed on the card — supplied with the list so no extra call is needed.
+  top_preview: LeaderboardEntry[];
 };
 
 export type PickemScore = {
@@ -38,7 +40,15 @@ export type MatchScore = {
   correct_outcomes: number;
 };
 
-export type CompetitionScore = PickemScore | MatchScore;
+export type AwardsScore = {
+  total: number;
+  golden_boot: number;
+  golden_ball: number;
+  golden_glove: number;
+  young_player: number;
+};
+
+export type CompetitionScore = PickemScore | MatchScore | AwardsScore;
 
 export type LeaderboardMember = {
   user_id: string;
@@ -61,17 +71,45 @@ export type LeaderboardPage = {
   has_more: boolean;
 };
 
+// Board-wide standing: per-type subtotals + raw-sum total. `custom` = match competitions.
+export type BoardSummaryEntry = {
+  member: LeaderboardMember;
+  rank: number;
+  total: number;
+  pickem: number;
+  custom: number;
+  pick: number;
+  awards: number;
+};
+
+export type BoardSummaryPage = {
+  items: BoardSummaryEntry[];
+  page: number;
+  limit: number;
+  total: number;
+  has_more: boolean;
+};
+
 export type CreateMatchCompetitionInput = {
   name: string;
   type: "match";
   scope: CompetitionScope;
 };
 
-export type CreatePoolCompetitionInput = {
+export type CreatePickCompetitionInput = {
   name: string;
-  type: "pool";
+  type: "pick";
   match_id: number;
 };
 
-// Pick'em is auto-seeded as the board's anchor competition and is never created here.
-export type CreateCompetitionInput = CreateMatchCompetitionInput | CreatePoolCompetitionInput;
+export type CreatePickemCompetitionInput = {
+  name: string;
+  type: "pickem";
+};
+
+export type CreateAwardsCompetitionInput = {
+  name: string;
+  type: "awards";
+};
+
+export type CreateCompetitionInput = CreateMatchCompetitionInput | CreatePickCompetitionInput | CreatePickemCompetitionInput | CreateAwardsCompetitionInput;

--- a/src/i18n/messages/api-errors/en.json
+++ b/src/i18n/messages/api-errors/en.json
@@ -23,6 +23,8 @@
   "NOT_BOARD_MEMBER": "You're not a member of this board.",
   "INVALID_BOARD_ID": "Invalid board.",
   "INVALID_USER_ID": "Invalid user.",
+  "COMPETITION_PICKEM_ALREADY_EXISTS": "A Pick'em competition already exists in this board.",
+  "COMPETITION_AWARDS_ALREADY_EXISTS": "An Awards competition already exists in this board.",
   "COMPETITION_NAME_ALREADY_EXISTS": "A competition with that name already exists in this board.",
   "COMPETITION_FORBIDDEN": "You no longer have permission to manage competitions in this board.",
   "UNKNOWN_ERROR": "An error occurred. Please try again."

--- a/src/i18n/messages/api-errors/es.json
+++ b/src/i18n/messages/api-errors/es.json
@@ -23,6 +23,8 @@
   "NOT_BOARD_MEMBER": "No eres miembro de este board.",
   "INVALID_BOARD_ID": "Board inválido.",
   "INVALID_USER_ID": "Usuario inválido.",
+  "COMPETITION_PICKEM_ALREADY_EXISTS": "Ya existe una competencia Pick'em en este board.",
+  "COMPETITION_AWARDS_ALREADY_EXISTS": "Ya existe una competencia de Premios en este board.",
   "COMPETITION_NAME_ALREADY_EXISTS": "Ya existe una competencia con ese nombre en este board.",
   "COMPETITION_FORBIDDEN": "Ya no tienes permiso para gestionar competencias en este board.",
   "UNKNOWN_ERROR": "Ocurrió un error. Por favor intenta de nuevo."

--- a/src/i18n/messages/boards/en.json
+++ b/src/i18n/messages/boards/en.json
@@ -5,6 +5,7 @@
   "members": "{count, plural, one {# member} other {# members}}",
   "tabs": {
     "competitions": "Competitions",
+    "summary": "Summary",
     "members": "Members"
   },
   "header": {
@@ -115,7 +116,7 @@
         "description": "Deleting the board removes all its members, competitions, and results. This can't be undone.",
         "cta": "Delete board",
         "confirm": "Delete {name}?",
-        "confirmDescription": "Type the board name to confirm.",
+        "typeToConfirm": "Type <b>{name}</b> to confirm",
         "cancel": "Cancel",
         "success": "Board deleted"
       }

--- a/src/i18n/messages/boards/es.json
+++ b/src/i18n/messages/boards/es.json
@@ -5,6 +5,7 @@
   "members": "{count, plural, one {# miembro} other {# miembros}}",
   "tabs": {
     "competitions": "Competencias",
+    "summary": "Resumen",
     "members": "Miembros"
   },
   "header": {
@@ -115,7 +116,7 @@
         "description": "Al eliminar el board se borrarán sus miembros, competencias y resultados. Esta acción no se puede deshacer.",
         "cta": "Eliminar board",
         "confirm": "¿Eliminar {name}?",
-        "confirmDescription": "Escribe el nombre del board para confirmar.",
+        "typeToConfirm": "Escribe <b>{name}</b> para confirmar",
         "cancel": "Cancelar",
         "success": "Board eliminado"
       }

--- a/src/i18n/messages/competitions/en.json
+++ b/src/i18n/messages/competitions/en.json
@@ -4,10 +4,12 @@
   "type": {
     "pickem": "Pick'em",
     "match": "Custom",
-    "pool": "Pool"
+    "pick": "Pick",
+    "awards": "Awards"
   },
   "defaultNames": {
-    "fullTournament": "Full tournament"
+    "fullTournament": "Full schedule",
+    "awards": "Awards"
   },
   "tabs": {
     "createCompetition": "New competition"
@@ -15,6 +17,7 @@
   "info": {
     "stagesCount": "{count, plural, one {# stage} other {# stages}}",
     "teamsCount": "{count, plural, one {# team} other {# teams}}",
+    "awardsCount": "{count, plural, one {# award} other {# awards}}",
     "rank": "Your position",
     "points": "Your points"
   },
@@ -36,6 +39,9 @@
       "thirds": "Thirds",
       "bracket": "Bracket"
     },
+    "awards": {
+      "label": "Individual honors"
+    },
     "hint": {
       "title": "{count, plural, one {# competition needs your picks} other {# competitions need your picks}}",
       "description": "Cards with an accent border are waiting on you — get your picks in before they lock.",
@@ -55,7 +61,7 @@
     "clearFilter": "Clear filter",
     "new": "New competition",
     "newShort": "New",
-    "newHint": "Custom · Pool"
+    "newHint": "Custom · Pick"
   },
   "leaderboard": {
     "memberCount": "{count, plural, one {# member} other {# members}}",
@@ -69,7 +75,11 @@
       "bestThirds": "B.3rds",
       "bracket": "Bracket",
       "exactHits": "Exact hits",
-      "outcomes": "Outcomes"
+      "outcomes": "Outcomes",
+      "golden_boot": "Boot",
+      "golden_ball": "Ball",
+      "golden_glove": "Glove",
+      "young_player": "U21"
     },
     "columnsLong": {
       "total": "Total points",
@@ -78,7 +88,11 @@
       "bestThirds": "Best thirds",
       "bracket": "Bracket hits",
       "exactHits": "Exact scores",
-      "outcomes": "Correct outcomes"
+      "outcomes": "Correct outcomes",
+      "golden_boot": "Golden Boot",
+      "golden_ball": "Golden Ball",
+      "golden_glove": "Golden Glove",
+      "young_player": "Young Player"
     },
     "you": "You",
     "empty": "No entries yet",
@@ -94,15 +108,23 @@
       "nextColumn": "Show {name}"
     }
   },
+  "summary": {
+    "columns": {
+      "pickem": "Pick'em",
+      "custom": "Custom",
+      "pick": "Picks",
+      "awards": "Awards"
+    }
+  },
   "emptyCompetitions": {
     "title": "No competitions yet",
-    "descriptionAdmin": "Create the first custom competition or pool for this board.",
+    "descriptionAdmin": "Create the first custom competition or pick for this board.",
     "descriptionMember": "Wait for an admin to add a competition.",
     "cta": "New competition"
   },
   "create": {
     "title": "New competition",
-    "description": "Set up a custom competition or a single-match pool.",
+    "description": "Set up a custom competition or a single-match pick.",
     "steps": {
       "details": "Details",
       "scope": "Scope",
@@ -112,19 +134,22 @@
     "type": {
       "label": "Type",
       "customDescription": "Score a slice of the tournament with custom stages and teams.",
-      "poolDescription": "A single match — everyone predicts the exact score."
+      "pickDescription": "A single match — everyone predicts the exact score.",
+      "pickemDescription": "The full tournament bracket — groups, thirds and knockouts.",
+      "awardsDescription": "The individual honors — golden boot, ball, glove and young player."
     },
     "match": {
       "search": "Search teams…",
-      "empty": "No upcoming matches to pool.",
+      "empty": "No upcoming matches to pick.",
       "vs": "vs"
     },
     "name": {
       "label": "Name",
       "placeholder": "e.g. Knockout run",
       "helper": "Up to 20 characters",
-      "poolPlaceholder": "Set from the match",
-      "poolHelper": "Named automatically from the match you pick."
+      "pickPlaceholder": "Set from the match",
+      "pickHelper": "Named automatically from the match you pick.",
+      "fixedHelper": "Named automatically — one per board."
     },
     "scope": {
       "stages": "Stages",
@@ -154,8 +179,9 @@
     "success": "Competition created"
   },
   "delete": {
-    "title": "Delete competition?",
-    "description": "{name} and all its picks will be removed for everyone on the board. This can't be undone.",
+    "title": "Delete {name}?",
+    "description": "{name} leaves this board, along with its leaderboard and summary points. Members' picks are kept — re-add it to bring the standings back.",
+    "typeToConfirm": "Type <b>{name}</b> to confirm",
     "confirm": "Delete competition",
     "cancel": "Cancel",
     "success": "Competition deleted"

--- a/src/i18n/messages/competitions/es.json
+++ b/src/i18n/messages/competitions/es.json
@@ -4,10 +4,12 @@
   "type": {
     "pickem": "Pick'em",
     "match": "Personalizada",
-    "pool": "Polla"
+    "pick": "Polla",
+    "awards": "Premios"
   },
   "defaultNames": {
-    "fullTournament": "Torneo completo"
+    "fullTournament": "Calendario completo",
+    "awards": "Premios"
   },
   "tabs": {
     "createCompetition": "Nueva competencia"
@@ -15,6 +17,7 @@
   "info": {
     "stagesCount": "{count, plural, one {# fase} other {# fases}}",
     "teamsCount": "{count, plural, one {# equipo} other {# equipos}}",
+    "awardsCount": "{count, plural, one {# premio} other {# premios}}",
     "rank": "Tu posición",
     "points": "Tus puntos"
   },
@@ -35,6 +38,9 @@
       "groups": "Grupos",
       "thirds": "Terceros",
       "bracket": "Llaves"
+    },
+    "awards": {
+      "label": "Premios individuales"
     },
     "hint": {
       "title": "{count, plural, one {# competencia espera tus pronósticos} other {# competencias esperan tus pronósticos}}",
@@ -69,7 +75,11 @@
       "bestThirds": "3eros",
       "bracket": "Bracket",
       "exactHits": "Exactos",
-      "outcomes": "Resultados"
+      "outcomes": "Resultados",
+      "golden_boot": "Bota",
+      "golden_ball": "Balón",
+      "golden_glove": "Guante",
+      "young_player": "Sub-21"
     },
     "columnsLong": {
       "total": "Puntos totales",
@@ -78,7 +88,11 @@
       "bestThirds": "Mejores terceros",
       "bracket": "Aciertos de llave",
       "exactHits": "Marcadores exactos",
-      "outcomes": "Resultados correctos"
+      "outcomes": "Resultados correctos",
+      "golden_boot": "Bota de Oro",
+      "golden_ball": "Balón de Oro",
+      "golden_glove": "Guante de Oro",
+      "young_player": "Jugador Joven"
     },
     "you": "Tú",
     "empty": "Aún no hay entradas",
@@ -94,15 +108,23 @@
       "nextColumn": "Mostrar {name}"
     }
   },
+  "summary": {
+    "columns": {
+      "pickem": "Pick'em",
+      "custom": "Personalizadas",
+      "pick": "Pollas",
+      "awards": "Premios"
+    }
+  },
   "emptyCompetitions": {
     "title": "Aún no hay competencias",
-    "descriptionAdmin": "Crea la primera competencia personalizada o pool de este board.",
+    "descriptionAdmin": "Crea la primera competencia personalizada o polla de este board.",
     "descriptionMember": "Espera a que un admin cree una competencia.",
     "cta": "Nueva competencia"
   },
   "create": {
     "title": "Nueva competencia",
-    "description": "Crea una competencia personalizada o un pool de un solo partido.",
+    "description": "Crea una competencia personalizada o una polla de un solo partido.",
     "steps": {
       "details": "Detalles",
       "scope": "Alcance",
@@ -112,19 +134,22 @@
     "type": {
       "label": "Tipo",
       "customDescription": "Puntúa una parte del torneo con fases y equipos a tu medida.",
-      "poolDescription": "Un solo partido: todos pronostican el marcador exacto."
+      "pickDescription": "Un solo partido: todos pronostican el marcador exacto.",
+      "pickemDescription": "El bracket completo del torneo: grupos, terceros y eliminatorias.",
+      "awardsDescription": "Los premios individuales: bota, balón, guante de oro y joven."
     },
     "match": {
       "search": "Busca equipos…",
-      "empty": "No hay próximos partidos para crear un pool.",
+      "empty": "No hay próximos partidos para crear una polla.",
       "vs": "vs"
     },
     "name": {
       "label": "Nombre",
       "placeholder": "p. ej. Eliminatorias",
       "helper": "Hasta 20 caracteres",
-      "poolPlaceholder": "Se define con el partido",
-      "poolHelper": "Se nombra automáticamente según el partido que elijas."
+      "pickPlaceholder": "Se define con el partido",
+      "pickHelper": "Se nombra automáticamente según el partido que elijas.",
+      "fixedHelper": "Se nombra automáticamente: una por board."
     },
     "scope": {
       "stages": "Fases",
@@ -154,8 +179,9 @@
     "success": "Competencia creada"
   },
   "delete": {
-    "title": "¿Eliminar competencia?",
-    "description": "Se borrarán {name} y todas sus picks para todos los miembros del board. No se puede deshacer.",
+    "title": "¿Eliminar {name}?",
+    "description": "{name} se quita de este tablero, junto con su clasificación y sus puntos en el resumen. Las picks de los miembros se conservan: vuelve a agregarla para recuperar las posiciones.",
+    "typeToConfirm": "Escribe <b>{name}</b> para confirmar",
     "confirm": "Eliminar competencia",
     "cancel": "Cancelar",
     "success": "Competencia eliminada"

--- a/src/i18n/messages/error/en.json
+++ b/src/i18n/messages/error/en.json
@@ -1,4 +1,6 @@
 {
   "title": "Something went wrong",
-  "description": "An unexpected error occurred"
+  "description": "An unexpected error occurred",
+  "hint": "Try refreshing the page, or come back later.",
+  "retry": "Try again"
 }

--- a/src/i18n/messages/error/es.json
+++ b/src/i18n/messages/error/es.json
@@ -1,4 +1,6 @@
 {
   "title": "Algo salió mal",
-  "description": "Ocurrió un error inesperado"
+  "description": "Ocurrió un error inesperado",
+  "hint": "Intenta refrescar la página o vuelve más tarde.",
+  "retry": "Reintentar"
 }

--- a/src/shared/components/ConfirmByTyping.tsx
+++ b/src/shared/components/ConfirmByTyping.tsx
@@ -15,8 +15,7 @@ type Props = {
   inputId: string;
 };
 
-// A destructive-action confirmation block: a warning callout plus a "type the name to confirm"
-// field. The caller owns the match check (enable/disable its confirm button).
+// Warning callout + "type the name to confirm" field; the caller owns the match check.
 export function ConfirmByTyping({ warning, label, value, onChange, placeholder, autoFocus, inputId }: Props) {
   return (
     <div className="flex flex-col gap-4">

--- a/src/shared/components/ConfirmByTyping.tsx
+++ b/src/shared/components/ConfirmByTyping.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { TriangleAlert } from "lucide-react";
+
+import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
+
+type Props = {
+  warning: React.ReactNode;
+  label: React.ReactNode;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+  inputId: string;
+};
+
+// A destructive-action confirmation block: a warning callout plus a "type the name to confirm"
+// field. The caller owns the match check (enable/disable its confirm button).
+export function ConfirmByTyping({ warning, label, value, onChange, placeholder, autoFocus, inputId }: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start gap-2.5 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm">
+        <TriangleAlert className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden />
+        <p className="leading-snug text-foreground">{warning}</p>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor={inputId} className="text-muted-foreground">
+          {label}
+        </Label>
+        <Input id={inputId} value={value} onChange={(event) => onChange(event.target.value)} placeholder={placeholder} autoFocus={autoFocus} autoComplete="off" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Related issue

Closes #74

## What changed

- Rename the `pool` competition type → `pick` (single-match) across the UI, with a normalize shim that tolerates legacy `pool` API responses
- Add a Board Summary tab aggregating per-competition points, with the Total column ordered last to match the summary pattern
- Integrate awards into competition cards and board views (CTA, lock state, detail header)
- Type-the-exact-name confirmation for deleting competitions and boards (shared `ConfirmByTyping`)
- Gate the "needs picks" card accent on pickable (teams-known) unpicked matches; error screen "Try again" now hard-refreshes

## How to test

- [ ] Open a board → Summary tab shows aggregated points with the Total column at the far right
- [ ] Open a pick (single-match) competition — card icon/label render, leaderboard loads
- [ ] On a competition with only TBD matches, confirm no "needs picks" accent border and no broken "Make your picks" deep link
- [ ] Delete a competition and a board — destructive action stays disabled until the exact name is typed; Cancel resets the field
- [ ] Trigger an error page, click "Try again" — UI hard-refreshes
- [ ] Awards competition card shows the correct CTA/lock state on both board grid and detail header