### PR TITLE
feat: leaderboard table & mobile cycler enhancements

### DIFF
--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -23,8 +23,7 @@ export default async function FaqPage({ params }: Props) {
   setRequestLocale(locale);
   const t = await getTranslations("pages.faq");
 
-  // Strip the next-intl rich-text markers (<rulesLink>…</rulesLink>) so the
-  // structured-data answer is plain prose, as Google's FAQPage spec requires.
+  const stripTags = { rulesLink: (c: string) => c, boardsLink: (c: string) => c, howItWorksLink: (c: string) => c };
   const faqJsonLd = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
@@ -33,7 +32,7 @@ export default async function FaqPage({ params }: Props) {
       name: t(`items.${key}.question`),
       acceptedAnswer: {
         "@type": "Answer",
-        text: t(`items.${key}.answer`).replace(/<\/?[a-zA-Z]+>/g, ""),
+        text: t.markup(`items.${key}.answer`, stripTags),
       },
     })),
   };

--- a/src/features/competitions/components/BoardSummaryTab.tsx
+++ b/src/features/competitions/components/BoardSummaryTab.tsx
@@ -1,20 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronsUpDown, ChevronUp, Crown, Search, User, X } from "lucide-react";
+import { ChevronDown, ChevronsUpDown, ChevronUp, Crown, Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-import { Avatar, AvatarFallback } from "@/shared/components/ui/avatar";
 import { Input } from "@/shared/components/ui/input";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { useDebounce } from "@/shared/hooks/useDebounce";
-import { displayName, getInitials } from "@/shared/lib/ui";
+import { displayName } from "@/shared/lib/ui";
 import { cn } from "@/shared/lib/utils";
 
 import { LEADERBOARD_PAGE_SIZE } from "../api/competitions";
 import { useBoardSummary } from "../hooks/useBoardSummary";
 import type { BoardSummaryEntry } from "../types/competitions.types";
 
+import { LeaderboardMobileTable, type MobileLeaderboardColumn } from "./LeaderboardMobileTable";
 import { LeaderboardPagination } from "./LeaderboardPagination";
 
 // Which per-type subtotal columns the board has (custom = match competitions).
@@ -46,9 +46,11 @@ export function BoardSummaryTab({ boardId, currentUserId, columns, enabled }: Pr
   const isLoading = query.isFetching && items.length === 0;
   const emptyLabel = debouncedQ.length > 0 ? t("noResults") : t("empty");
 
-  // Sortable keys in display order: the per-type subtotals, then the overall total.
-  const sortKeys: SortKey[] = [...columns, "total"];
-  const sortLabel = (key: SortKey) => (key === "total" ? t("columns.total") : tCol(key));
+  // Mobile cycler columns: the per-type subtotals, then the overall total.
+  const mobileColumns: MobileLeaderboardColumn<BoardSummaryEntry>[] = [
+    ...columns.map((col) => ({ id: col, label: tCol(col), value: (e: BoardSummaryEntry) => e[col] })),
+    { id: "total", label: t("columns.total"), value: (e: BoardSummaryEntry) => e.total },
+  ];
 
   function onSearch(value: string) {
     setQ(value);
@@ -56,11 +58,12 @@ export function BoardSummaryTab({ boardId, currentUserId, columns, enabled }: Pr
   }
 
   // Click a new column → sort it descending; click the active column → flip direction.
-  function onSort(key: SortKey) {
+  // `key` is always a valid SortKey (column id); typed as string to match the shared cycler.
+  function onSort(key: string) {
     if (key === sort) {
       setDir((d) => (d === "desc" ? "asc" : "desc"));
     } else {
-      setSort(key);
+      setSort(key as SortKey);
       setDir("desc");
     }
     setPage(1);
@@ -87,7 +90,7 @@ export function BoardSummaryTab({ boardId, currentUserId, columns, enabled }: Pr
         {/* Desktop */}
         <table className="hidden w-full border-collapse text-sm md:table">
           <thead>
-            <tr className="border-b border-border bg-muted/40 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <tr className="border-b border-border bg-muted/40 text-xs font-semibold text-muted-foreground">
               <th className="w-12 px-4 py-2.5 text-center">{t("columns.rank")}</th>
               <th className="w-full px-4 py-2.5 text-left">{t("columns.member")}</th>
               {columns.map((col) => (
@@ -150,60 +153,19 @@ export function BoardSummaryTab({ boardId, currentUserId, columns, enabled }: Pr
         </table>
 
         {/* Mobile */}
-        <div className="md:hidden">
-          <div className="flex flex-wrap gap-1.5 border-b border-border px-3 py-2.5">
-            {sortKeys.map((key) => (
-              <button
-                key={key}
-                type="button"
-                onClick={() => onSort(key)}
-                aria-pressed={sort === key}
-                className={cn(
-                  "inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-2xs font-medium transition-colors",
-                  sort === key ? "border-page-accent-strong/30 bg-page-accent-soft text-page-accent-strong" : "border-border text-muted-foreground hover:bg-muted"
-                )}
-              >
-                {sortLabel(key)}
-                {sort === key ? <DirChevron dir={dir} /> : null}
-              </button>
-            ))}
-          </div>
-          {isLoading ? (
-            <ul className="divide-y divide-border">
-              {Array.from({ length: LEADERBOARD_PAGE_SIZE }).map((_, i) => (
-                <li key={i} className="flex items-center gap-3 px-3 py-2.5">
-                  <Skeleton className="h-3.5 w-6" />
-                  <Skeleton className="h-9 flex-1" />
-                </li>
-              ))}
-            </ul>
-          ) : items.length === 0 ? (
-            <p className="py-10 text-center text-sm text-muted-foreground">{emptyLabel}</p>
-          ) : (
-            <ul className="divide-y divide-border">
-              {items.map((entry) => {
-                const isMe = entry.member.user_id === currentUserId;
-                return (
-                  <li key={entry.member.user_id} className={cn("flex items-center gap-3 px-3 py-2.5", isMe && "bg-page-accent-soft/60")}>
-                    <span className="w-6 shrink-0 text-center">
-                      <RankBadge rank={entry.rank} />
-                    </span>
-                    <div className="flex min-w-0 flex-1 flex-col gap-1">
-                      <MemberCell entry={entry} isMe={isMe} youLabel={t("you")} />
-                      <span className="flex flex-wrap gap-x-2 text-2xs text-muted-foreground tabular-nums">
-                        {columns.map((col) => (
-                          <span key={col}>
-                            {tCol(col)} {entry[col].toLocaleString()}
-                          </span>
-                        ))}
-                      </span>
-                    </div>
-                    <span className="shrink-0 font-mono text-base font-semibold tabular-nums">{entry.total.toLocaleString()}</span>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
+        <div className="p-4 md:hidden">
+          <LeaderboardMobileTable
+            rows={items}
+            columns={mobileColumns}
+            getMember={(row) => row.member}
+            getRank={(row) => row.rank}
+            currentUserId={currentUserId}
+            isLoading={isLoading}
+            emptyLabel={emptyLabel}
+            sort={sort}
+            dir={dir}
+            onSort={onSort}
+          />
         </div>
 
         {totalPages > 1 ? (
@@ -250,14 +212,7 @@ function RankBadge({ rank }: { rank: number }) {
 
 function MemberCell({ entry, isMe, youLabel }: { entry: BoardSummaryEntry; isMe: boolean; youLabel: string }) {
   return (
-    <span className="flex min-w-0 items-center gap-2">
-      <Avatar className="size-6 border border-border">
-        <AvatarFallback className="bg-card text-2xs font-semibold text-foreground">
-          {getInitials(entry.member.username, entry.member.first_name ?? undefined, entry.member.last_name ?? undefined) || (
-            <User className="size-3 text-muted-foreground" aria-hidden />
-          )}
-        </AvatarFallback>
-      </Avatar>
+    <span className="flex min-w-0 items-center gap-1.5">
       <span className="min-w-0 truncate font-medium">{displayName(entry.member.username, entry.member.first_name, entry.member.last_name)}</span>
       {isMe ? <span className="shrink-0 rounded-md bg-page-accent p-1 text-2xs font-medium uppercase tracking-wide text-white">{youLabel}</span> : null}
     </span>

--- a/src/features/competitions/components/LeaderboardMobileTable.tsx
+++ b/src/features/competitions/components/LeaderboardMobileTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, X } from "lucide-react";
+import { useState, type TouchEvent } from "react";
+import { ArrowDownWideNarrow, ArrowUpNarrowWide, Check, ChevronLeft, ChevronRight, MoveHorizontal, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/shared/components/ui/button";
@@ -9,12 +10,27 @@ import { displayName } from "@/shared/lib/ui";
 import { cn } from "@/shared/lib/utils";
 
 import { LEADERBOARD_PAGE_SIZE } from "../api/competitions";
-import type { MobileCyclableColumn } from "../lib/competitionColumns";
-import type { LeaderboardEntry } from "../types/competitions.types";
 
-type Props = {
-  rows: LeaderboardEntry[];
-  cyclableColumns: MobileCyclableColumn[];
+export type MobileLeaderboardMember = {
+  user_id: string;
+  username: string;
+  first_name: string | null;
+  last_name: string | null;
+};
+
+export type MobileLeaderboardColumn<T> = {
+  id: string;
+  label: string; // already translated
+  value: (row: T) => number;
+  // "check" renders the 0|1 value as a ✓/✗ instead of a number (awards).
+  display?: "check";
+};
+
+type Props<T> = {
+  rows: T[];
+  columns: MobileLeaderboardColumn<T>[];
+  getMember: (row: T) => MobileLeaderboardMember;
+  getRank: (row: T) => number;
   currentUserId: string;
   isLoading: boolean;
   emptyLabel: string;
@@ -23,48 +39,74 @@ type Props = {
   onSort: (key: string) => void;
 };
 
-// The cycler picks which metric to show AND sorts by it; tapping the active
-// column label flips the direction.
-export function LeaderboardMobileTable({ rows, cyclableColumns, currentUserId, isLoading, emptyLabel, sort, dir, onSort }: Props) {
+// Fixed rank + metric columns so the value (and the header sort control) center in
+// the same column across header and every row; the member column absorbs the slack.
+const GRID = "grid grid-cols-[2.25rem_1fr_7.5rem] items-center gap-3";
+
+// One metric is visible at a time: the arrows (or a swipe) cycle which column,
+// and the "Order" line flips the sort direction. Shared by the competition
+// leaderboard and the board summary so both read the same on mobile.
+export function LeaderboardMobileTable<T>({ rows, columns, getMember, getRank, currentUserId, isLoading, emptyLabel, sort, dir, onSort }: Props<T>) {
   const t = useTranslations("competitions.leaderboard");
-  const tCols = useTranslations("competitions.leaderboard.columns");
 
   const activeIdx = Math.max(
     0,
-    cyclableColumns.findIndex((c) => c.id === sort)
+    columns.findIndex((c) => c.id === sort)
   );
-  const active = cyclableColumns[activeIdx] ?? cyclableColumns[0];
-  const prev = cyclableColumns[(activeIdx - 1 + cyclableColumns.length) % cyclableColumns.length];
-  const next = cyclableColumns[(activeIdx + 1) % cyclableColumns.length];
+  const active = columns[activeIdx] ?? columns[0];
+  const prev = columns[(activeIdx - 1 + columns.length) % columns.length];
+  const next = columns[(activeIdx + 1) % columns.length];
+  const single = columns.length <= 1;
+
+  // Swipe left → next metric, right → previous (mirrors the chevron buttons).
+  const [touchX, setTouchX] = useState<number | null>(null);
+  function onTouchEnd(e: TouchEvent) {
+    if (touchX === null || single) return;
+    const dx = e.changedTouches[0].clientX - touchX;
+    if (Math.abs(dx) > 40) onSort((dx < 0 ? next : prev).id);
+    setTouchX(null);
+  }
+
+  if (!active) return null;
 
   return (
-    <div className="flex flex-col">
-      <div className="grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b border-border px-2 pb-2 text-2xs font-medium uppercase tracking-wider text-muted-foreground">
-        <span className="w-9">{t("columns.rank")}</span>
-        <span>{t("columns.member")}</span>
-        <div className="flex w-28 items-center justify-between gap-0.5">
+    <div className="flex flex-col" onTouchStart={(e) => setTouchX(e.touches[0].clientX)} onTouchEnd={onTouchEnd}>
+      <div className={cn(GRID, "border-b border-border pb-2.5")}>
+        <span className="text-center text-2xs font-semibold tracking-wide text-muted-foreground uppercase">{t("columns.rank")}</span>
+        <span className="text-2xs font-semibold tracking-wide text-muted-foreground uppercase">{t("columns.member")}</span>
+        <div className="flex min-w-0 items-center justify-center gap-0.5">
           <Button
             type="button"
             variant="ghost"
             size="icon-sm"
             onClick={() => onSort(prev.id)}
-            disabled={cyclableColumns.length <= 1}
-            aria-label={t("mobile.prevColumn", { name: tCols(prev.labelKey) })}
+            disabled={single}
+            aria-label={t("mobile.prevColumn", { name: prev.label })}
             className="size-6 shrink-0"
           >
             <ChevronLeft className="size-3.5" aria-hidden />
           </Button>
-          <button type="button" onClick={() => onSort(active.id)} className="flex flex-1 cursor-pointer items-center justify-center gap-0.5 tabular-nums text-foreground">
-            {tCols(active.labelKey)}
-            {dir === "asc" ? <ChevronUp className="size-3" aria-hidden /> : <ChevronDown className="size-3" aria-hidden />}
+          {/* Tapping the active column flips the sort direction; the accent sort icon shows which way. */}
+          <button
+            type="button"
+            onClick={() => onSort(active.id)}
+            aria-label={t("mobile.toggleSort")}
+            className="flex min-w-0 items-center gap-1 text-xs font-semibold text-foreground transition-colors hover:text-muted-foreground"
+          >
+            <span className="truncate">{active.label}</span>
+            {dir === "asc" ? (
+              <ArrowUpNarrowWide className="size-3.5 shrink-0 text-page-accent-strong" aria-hidden />
+            ) : (
+              <ArrowDownWideNarrow className="size-3.5 shrink-0 text-page-accent-strong" aria-hidden />
+            )}
           </button>
           <Button
             type="button"
             variant="ghost"
             size="icon-sm"
             onClick={() => onSort(next.id)}
-            disabled={cyclableColumns.length <= 1}
-            aria-label={t("mobile.nextColumn", { name: tCols(next.labelKey) })}
+            disabled={single}
+            aria-label={t("mobile.nextColumn", { name: next.label })}
             className="size-6 shrink-0"
           >
             <ChevronRight className="size-3.5" aria-hidden />
@@ -75,17 +117,13 @@ export function LeaderboardMobileTable({ rows, cyclableColumns, currentUserId, i
       {isLoading ? (
         <ul className="divide-y divide-border">
           {Array.from({ length: LEADERBOARD_PAGE_SIZE }).map((_, i) => (
-            <li key={i} className="grid grid-cols-[auto_1fr_auto] items-center gap-3 px-2 py-2.5">
-              <span className="w-9">
-                <Skeleton className="h-3.5 w-6" />
-              </span>
+            <li key={i} className={cn(GRID, "py-2.5")}>
+              <Skeleton className="h-3.5 w-7 justify-self-center" />
               <div className="flex flex-col gap-1.5">
                 <Skeleton className="h-4 w-28" />
                 <Skeleton className="h-2.5 w-16" />
               </div>
-              <span className="flex w-28 justify-center">
-                <Skeleton className="h-4 w-10" />
-              </span>
+              <Skeleton className="h-5 w-8 justify-self-center" />
             </li>
           ))}
         </ul>
@@ -93,29 +131,31 @@ export function LeaderboardMobileTable({ rows, cyclableColumns, currentUserId, i
         <p className="py-10 text-center text-sm text-muted-foreground">{emptyLabel}</p>
       ) : (
         <ul className="divide-y divide-border">
-          {rows.map((entry) => {
-            const isMe = entry.member.user_id === currentUserId;
+          {rows.map((row) => {
+            const member = getMember(row);
+            const rank = getRank(row);
+            const isMe = member.user_id === currentUserId;
             return (
-              <li key={entry.member.user_id} className={cn("grid grid-cols-[auto_1fr_auto] items-center gap-3 px-2 py-2.5", isMe && "bg-page-accent-soft/60")}>
-                <span className="w-9 shrink-0 text-xs font-medium tabular-nums text-muted-foreground">{String(entry.rank).padStart(2, "0")}</span>
+              <li key={member.user_id} className={cn(GRID, "py-2.5", isMe && "bg-page-accent-soft/60")}>
+                <span className="text-center text-xs font-medium text-muted-foreground tabular-nums">{String(rank).padStart(2, "0")}</span>
                 <div className="flex min-w-0 flex-col leading-tight">
                   <span className="flex min-w-0 items-center gap-1.5">
                     <span className={cn("truncate text-sm font-medium", isMe && "text-page-accent-strong")}>
-                      {displayName(entry.member.username, entry.member.first_name, entry.member.last_name)}
+                      {displayName(member.username, member.first_name, member.last_name)}
                     </span>
-                    {isMe ? <span className="rounded-md bg-page-accent p-1 text-2xs font-medium uppercase tracking-wide text-white">{t("you")}</span> : null}
+                    {isMe ? <span className="rounded-md bg-page-accent p-1 text-2xs font-medium tracking-wide text-white uppercase">{t("you")}</span> : null}
                   </span>
-                  <span className="truncate text-xs text-muted-foreground">@{entry.member.username}</span>
+                  <span className="truncate text-xs text-muted-foreground">@{member.username}</span>
                 </div>
-                <span className="flex w-28 justify-center text-base font-semibold tabular-nums">
+                <span className="flex justify-center text-sm font-semibold tabular-nums">
                   {active.display === "check" ? (
-                    active.value(entry) === 1 ? (
+                    active.value(row) === 1 ? (
                       <Check className="size-4 text-lime-600 dark:text-lime-400" aria-hidden />
                     ) : (
                       <X className="size-4 text-muted-foreground/40" aria-hidden />
                     )
                   ) : (
-                    active.value(entry).toLocaleString()
+                    active.value(row).toLocaleString()
                   )}
                 </span>
               </li>
@@ -123,6 +163,13 @@ export function LeaderboardMobileTable({ rows, cyclableColumns, currentUserId, i
           })}
         </ul>
       )}
+
+      {!single && !isLoading && rows.length > 0 ? (
+        <div className="mt-1 flex items-center justify-center gap-2 border-t border-border/60 pt-3 text-2xs text-muted-foreground">
+          <MoveHorizontal className="size-3.5 shrink-0 text-page-accent-strong" aria-hidden />
+          <span>{t("mobile.hint")}</span>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/features/competitions/components/LeaderboardSection.tsx
+++ b/src/features/competitions/components/LeaderboardSection.tsx
@@ -36,8 +36,14 @@ export function LeaderboardSection({ boardId, competition, currentUserId, initia
   const sort = searchParams.get(SORT_PARAM) ?? "total";
   const dir = searchParams.get(DIR_PARAM) === "asc" ? "asc" : "desc";
 
+  const tCols = useTranslations("competitions.leaderboard.columns");
+
   const columns = useMemo(() => buildColumns(competition.type), [competition.type]);
-  const cyclableColumns = useMemo(() => buildMobileCyclableColumns(competition.type), [competition.type]);
+  // Short labels: the cycler shows one metric in a fixed-width column, so they must stay compact.
+  const mobileColumns = useMemo(
+    () => buildMobileCyclableColumns(competition.type).map((col) => ({ id: col.id, label: tCols(col.labelKey), value: col.value, display: col.display })),
+    [competition.type, tCols]
+  );
 
   const query = useLeaderboard({
     boardId,
@@ -95,7 +101,9 @@ export function LeaderboardSection({ boardId, competition, currentUserId, initia
       <div className="p-4 md:hidden">
         <LeaderboardMobileTable
           rows={items}
-          cyclableColumns={cyclableColumns}
+          columns={mobileColumns}
+          getMember={(row) => row.member}
+          getRank={(row) => row.rank}
           currentUserId={currentUserId}
           isLoading={isLoading}
           emptyLabel={emptyLabel}

--- a/src/features/competitions/components/LeaderboardTable.tsx
+++ b/src/features/competitions/components/LeaderboardTable.tsx
@@ -40,16 +40,17 @@ export function LeaderboardTable({ columns, rows, currentUserId, isLoading, empt
     <table className="w-full border-collapse text-sm">
       <thead>
         {table.getHeaderGroups().map((headerGroup) => (
-          <tr key={headerGroup.id} className="border-b border-border bg-muted/40 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <tr key={headerGroup.id} className="border-b border-border bg-muted/40 text-xs font-semibold text-muted-foreground">
             {headerGroup.headers.map((header) => {
               const meta = header.column.columnDef.meta;
               const headerKey = header.column.columnDef.header as string;
               const isNumeric = headerKey !== "rank" && headerKey !== "member";
               const isActive = sort === headerKey;
+              // Desktop has room for the full column name; the short `columns` set is for the mobile cycler.
+              const label = isNumeric ? tColsLong(headerKey) : tCols(headerKey);
               return (
                 <th
                   key={header.id}
-                  title={isNumeric ? tColsLong(headerKey) : undefined}
                   aria-sort={isActive ? (dir === "asc" ? "ascending" : "descending") : undefined}
                   className={cn(
                     "px-4 py-2.5 whitespace-nowrap",
@@ -65,7 +66,7 @@ export function LeaderboardTable({ columns, rows, currentUserId, isLoading, empt
                       onClick={() => onSort(headerKey)}
                       className={cn("inline-flex cursor-pointer items-center gap-1 transition-colors hover:text-foreground", isActive && "text-foreground")}
                     >
-                      {tCols(headerKey)}
+                      {label}
                       {isActive ? (
                         dir === "asc" ? (
                           <ChevronUp className="size-3" aria-hidden />
@@ -77,7 +78,7 @@ export function LeaderboardTable({ columns, rows, currentUserId, isLoading, empt
                       )}
                     </button>
                   ) : (
-                    tCols(headerKey)
+                    label
                   )}
                 </th>
               );

--- a/src/i18n/messages/competitions/en.json
+++ b/src/i18n/messages/competitions/en.json
@@ -75,20 +75,20 @@
       "bestThirds": "B.3rds",
       "bracket": "Bracket",
       "exactHits": "Exact hits",
-      "outcomes": "Outcomes",
+      "outcomes": "Winner",
       "golden_boot": "Boot",
       "golden_ball": "Ball",
       "golden_glove": "Glove",
       "young_player": "U21"
     },
     "columnsLong": {
-      "total": "Total points",
-      "groupExact": "Exact group positions",
-      "groupQualifiers": "Group qualifiers",
+      "total": "Total",
+      "groupExact": "Exact groups",
+      "groupQualifiers": "Qualifiers",
       "bestThirds": "Best thirds",
-      "bracket": "Bracket hits",
+      "bracket": "Bracket",
       "exactHits": "Exact scores",
-      "outcomes": "Correct outcomes",
+      "outcomes": "Winner",
       "golden_boot": "Golden Boot",
       "golden_ball": "Golden Ball",
       "golden_glove": "Golden Glove",
@@ -105,7 +105,9 @@
     },
     "mobile": {
       "prevColumn": "Show {name}",
-      "nextColumn": "Show {name}"
+      "nextColumn": "Show {name}",
+      "toggleSort": "Change sort direction",
+      "hint": "Swipe or use the arrows to change the visible column"
     }
   },
   "summary": {

--- a/src/i18n/messages/competitions/es.json
+++ b/src/i18n/messages/competitions/es.json
@@ -75,20 +75,20 @@
       "bestThirds": "3eros",
       "bracket": "Bracket",
       "exactHits": "Exactos",
-      "outcomes": "Resultados",
+      "outcomes": "Ganador",
       "golden_boot": "Bota",
       "golden_ball": "Balón",
       "golden_glove": "Guante",
       "young_player": "Sub-21"
     },
     "columnsLong": {
-      "total": "Puntos totales",
-      "groupExact": "Posiciones exactas de grupo",
-      "groupQualifiers": "Clasificados de grupo",
+      "total": "Total",
+      "groupExact": "Grupos exactos",
+      "groupQualifiers": "Clasificados",
       "bestThirds": "Mejores terceros",
-      "bracket": "Aciertos de llave",
+      "bracket": "Bracket",
       "exactHits": "Marcadores exactos",
-      "outcomes": "Resultados correctos",
+      "outcomes": "Ganador",
       "golden_boot": "Bota de Oro",
       "golden_ball": "Balón de Oro",
       "golden_glove": "Guante de Oro",
@@ -105,7 +105,9 @@
     },
     "mobile": {
       "prevColumn": "Mostrar {name}",
-      "nextColumn": "Mostrar {name}"
+      "nextColumn": "Mostrar {name}",
+      "toggleSort": "Cambiar el orden",
+      "hint": "Desliza o usa las flechas para cambiar la columna visible"
     }
   },
   "summary": {

--- a/src/shared/components/JsonLd.tsx
+++ b/src/shared/components/JsonLd.tsx
@@ -1,13 +1,15 @@
-// Inert structured data. The real type is set only on the server so React doesn't warn about a
-// <script> rendered during client navigation; suppressHydrationWarning covers the type swap. The
-// `<` escape prevents a `</script>` breakout. Crawlers read the server HTML, which carries the
-// correct `application/ld+json`.
+"use client";
+
+import { useEffect } from "react";
+
+let hydrated = false;
+
 export function JsonLd({ data }: { data: Record<string, unknown> }) {
-  return (
-    <script
-      type={typeof window === "undefined" ? "application/ld+json" : "text/plain"}
-      suppressHydrationWarning
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(data).replace(/</g, "\\u003c") }}
-    />
-  );
+  useEffect(() => {
+    hydrated = true;
+  }, []);
+
+  if (typeof window !== "undefined" && hydrated) return null;
+
+  return <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(data).replace(/</g, "\\u003c") }} />;
 }


### PR DESCRIPTION
## What changed

- Reworked desktop leaderboard + board-summary table headers: full column names, legible normal-case titles (was tiny uppercase abbreviations)
- Unified the competition leaderboard and board summary mobile views into one shared `LeaderboardMobileTable` cycler — toggle the active column (arrows/swipe), flip sort direction (accent sort icon), centered values
- Removed avatars (desktop summary + mobile) and the rank crown on mobile so all leaderboard tables match
- Renamed the "Outcomes"/"Resultados" column to "Winner"/"Ganador" (it tracks correct winner, not exact score)
- Fix: FAQ JSON-LD threw `FORMATTING_ERROR` — resolve rich-text tags via `t.markup`
- Fix: `JsonLd` React 19 "script during client render" warning on locale switch — skip the client-created script after hydration

## How to test

- [ ] Board → Resumen on desktop: headers read as full titles, no avatars
- [ ] Resumen on mobile: cycle columns via arrows/swipe, tap the label to flip sort, values centered under the header
- [ ] Open a pick'em/match competition leaderboard: desktop shows full names, mobile shows short labels
- [ ] Confirm match/pick leaderboard column reads "Winner" / "Ganador"
- [ ] Visit /faq: no `FORMATTING_ERROR` in console; switch language → no React `<script>` warning