### PR TITLE
fix: attach token to OAuth bootstrap profile fetch

### DIFF
--- a/src/app/[locale]/(auth)/callback/page.tsx
+++ b/src/app/[locale]/(auth)/callback/page.tsx
@@ -35,7 +35,7 @@ export default function CallbackPage() {
 
         const { access_token, expires_at } = res.data!;
 
-        const profileRes = await getProfile();
+        const profileRes = await getProfile(access_token);
         if (!profileRes.success) {
           apiError.set(profileRes.error);
           return;

--- a/src/features/auth/api/client.ts
+++ b/src/features/auth/api/client.ts
@@ -39,7 +39,14 @@ export const logout = async (): Promise<ApiResponse> => {
   return api.post("/api/auth/logout", undefined, { authenticated: false });
 };
 
-export const getProfile = async (): Promise<ApiResponse<User>> => {
+export const getProfile = async (accessToken?: string): Promise<ApiResponse<User>> => {
+  if (accessToken) {
+    return api.get<User>("/api/users/profile", {
+      authenticated: false,
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  }
+
   return api.get<User>("/api/users/profile", { authenticated: true });
 };
 


### PR DESCRIPTION
## Related issue

Closes #82

## What changed

- Fixed a race in the Google OAuth callback where `getProfile()` ran before the NextAuth session existed, sending `GET /api/users/profile` with no `Authorization` header → a spurious `401 MISSING_AUTH_HEADER` on every Google sign-in.
- `getProfile(accessToken?)` now accepts the freshly-refreshed token and attaches `Authorization: Bearer …` directly (with `authenticated: false`), skipping the session lookup and the reactive-refresh retry during bootstrap.
- Callback page passes the bootstrap `access_token` into `getProfile()`.

## How to test

- [ ] Sign in with Google and confirm you land authenticated on the callback target.
- [ ] Watch the network tab: the first `GET /api/users/profile` carries an `Authorization` header and returns 200 (no preceding 401).
- [ ] Confirm backend logs no longer show `MISSING_AUTH_HEADER` for `/api/users/profile` after a Google login.
- [ ] Email/OTP login still works (callback path unaffected).