### PR TITLE
chore: release v1.2.1

### DIFF
--- a/src/app/[locale]/(auth)/callback/page.tsx
+++ b/src/app/[locale]/(auth)/callback/page.tsx
@@ -35,7 +35,7 @@ export default function CallbackPage() {
 
         const { access_token, expires_at } = res.data!;
 
-        const profileRes = await getProfile();
+        const profileRes = await getProfile(access_token);
         if (!profileRes.success) {
           apiError.set(profileRes.error);
           return;

--- a/src/features/auth/api/client.ts
+++ b/src/features/auth/api/client.ts
@@ -39,7 +39,14 @@ export const logout = async (): Promise<ApiResponse> => {
   return api.post("/api/auth/logout", undefined, { authenticated: false });
 };
 
-export const getProfile = async (): Promise<ApiResponse<User>> => {
+export const getProfile = async (accessToken?: string): Promise<ApiResponse<User>> => {
+  if (accessToken) {
+    return api.get<User>("/api/users/profile", {
+      authenticated: false,
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  }
+
   return api.get<User>("/api/users/profile", { authenticated: true });
 };
 


### PR DESCRIPTION
## Release v1.2.1

Patch release fixing a spurious auth error on Google sign-in.

### Fixes
- Google OAuth callback no longer fires `GET /api/users/profile` without an `Authorization` header before the session is set, eliminating the `MISSING_AUTH_HEADER` 401 (and a wasted refresh round-trip) on every Google login (#83).