### PR TITLE
chore: release v1.2.2

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,7 +18,6 @@ const nextConfig: NextConfig = {
       // /api/auth/token, /api/auth/token/refresh, and /api/auth/logout are omitted —
       // they have dedicated route handlers that manage the refresh-token cookie
       beforeFiles: [
-        { source: "/api/auth/otp/:path*", destination: `${upstream}/api/auth/otp/:path*` },
         { source: "/api/auth/logout/all", destination: `${upstream}/api/auth/logout/all` },
         { source: "/api/auth/sessions", destination: `${upstream}/api/auth/sessions` },
         { source: "/api/auth/sessions/:id", destination: `${upstream}/api/auth/sessions/:id` },
@@ -28,16 +27,10 @@ const nextConfig: NextConfig = {
         { source: "/api/oauth/:path((?!google/callback).*)", destination: `${upstream}/api/oauth/:path*` },
       ],
 
-      // afterFiles: proxy non-auth API routes to the backend
-      // Excludes paths owned by custom route handlers (e.g. matches/:id/pick, pickems/{groups,best-thirds,bracket}, boards/*, competitions/*, awards) —
-      // afterFiles rewrites run before dynamic routes, so a match here would swallow them.
-      // `awards` is excluded (GET+PUT route handler revalidates its cache tag); `players` is NOT — it has no handler and proxies straight through.
-      afterFiles: [
-        {
-          source: "/api/:path((?!auth/|matches/[^/]+/pick|pickems/(?:groups|best-thirds|bracket)|boards(?:/.*)?|competitions(?:/.*)?|awards(?:/.*)?).*)",
-          destination: `${upstream}/api/:path*`,
-        },
-      ],
+      // Non-auth API routes are proxied by the catch-all route handler at
+      // src/app/api/[...path]/route.ts (Node runtime), so it can attach the trusted
+      // X-Client-IP header — a rewrite would drop proxy-set request headers.
+      afterFiles: [],
 
       fallback: [],
     };

--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from "next/server";
+
+import { proxyToBackend } from "../_lib/proxy";
+
+// Catch-all proxy for backend API paths that have no dedicated route handler
+// (e.g. /api/matches, /api/standings, /api/dashboard, /api/players, /api/pickems).
+// Runs in the Node runtime, so forwardedClientHeaders can attach the trusted
+// X-Client-IP header — unlike a next.config rewrite, which drops proxy-set headers.
+// More specific route handlers and the beforeFiles rewrites take precedence over this.
+type Ctx = { params: Promise<{ path: string[] }> };
+
+const backendPath = (segments: string[]) => `/api/${segments.join("/")}`;
+
+export async function GET(req: NextRequest, { params }: Ctx) {
+  const { path } = await params;
+  return proxyToBackend(req, { path: backendPath(path), method: "GET" });
+}
+
+export async function POST(req: NextRequest, { params }: Ctx) {
+  const { path } = await params;
+  return proxyToBackend(req, { path: backendPath(path), method: "POST" });
+}
+
+export async function PUT(req: NextRequest, { params }: Ctx) {
+  const { path } = await params;
+  return proxyToBackend(req, { path: backendPath(path), method: "PUT" });
+}
+
+export async function PATCH(req: NextRequest, { params }: Ctx) {
+  const { path } = await params;
+  return proxyToBackend(req, { path: backendPath(path), method: "PATCH" });
+}
+
+export async function DELETE(req: NextRequest, { params }: Ctx) {
+  const { path } = await params;
+  return proxyToBackend(req, { path: backendPath(path), method: "DELETE" });
+}

--- a/src/app/api/_lib/proxy.ts
+++ b/src/app/api/_lib/proxy.ts
@@ -1,6 +1,8 @@
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
+import { forwardedClientHeaders } from "@/shared/lib/api/forwarded-headers";
+
 const UPSTREAM = process.env.BACKEND_API_URL;
 
 type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -13,8 +15,8 @@ type ProxyOptions = {
 };
 
 export async function proxyToBackend(req: NextRequest, options: ProxyOptions): Promise<NextResponse> {
+  const headers: Record<string, string> = forwardedClientHeaders(req);
   const auth = req.headers.get("authorization");
-  const headers: HeadersInit = {};
   if (auth) headers.Authorization = auth;
 
   const init: RequestInit = { method: options.method, headers };
@@ -24,7 +26,7 @@ export async function proxyToBackend(req: NextRequest, options: ProxyOptions): P
     const raw = await req.text();
     if (raw.length > 0) {
       init.body = raw;
-      (headers as Record<string, string>)["Content-Type"] = req.headers.get("content-type") ?? "application/json";
+      headers["Content-Type"] = req.headers.get("content-type") ?? "application/json";
     }
   }
 

--- a/src/app/api/auth/_lib/token-proxy.ts
+++ b/src/app/api/auth/_lib/token-proxy.ts
@@ -1,18 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+
+export { forwardedClientHeaders } from "@/shared/lib/api/forwarded-headers";
 
 export const REFRESH_COOKIE = "refresh_token";
 export const UPSTREAM = process.env.BACKEND_API_URL!;
-
-export function forwardedClientHeaders(req: NextRequest): Record<string, string> {
-  const headers: Record<string, string> = {};
-  const ua = req.headers.get("user-agent");
-  if (ua) headers["User-Agent"] = ua;
-  // Prefer an already-set X-Forwarded-For from a load balancer; otherwise use the
-  // direct client IP from the Next.js connection.
-  const xff = req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip");
-  if (xff) headers["X-Forwarded-For"] = xff;
-  return headers;
-}
 
 // Re-sets the refresh-token cookie at path="/" so it is visible on every route.
 // Also clears the backend's natural Path=/api/auth copy — the Google OAuth callback

--- a/src/app/api/auth/otp/[...rest]/route.ts
+++ b/src/app/api/auth/otp/[...rest]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from "next/server";
+
+import { proxyToBackend } from "../../../_lib/proxy";
+
+// Dedicated proxy for the OTP endpoints (/api/auth/otp/request, /api/auth/otp/verify).
+// Runs in the Node runtime so forwardedClientHeaders attaches the trusted X-Client-IP —
+// OTP send is IP-rate-limited, so the real client IP must reach the backend. This nested
+// route out-prioritizes the /api/auth/[...nextauth] catch-all, which would otherwise
+// swallow these paths; it replaces the former next.config beforeFiles rewrite.
+type Ctx = { params: Promise<{ rest: string[] }> };
+
+export async function POST(req: NextRequest, { params }: Ctx) {
+  const { rest } = await params;
+  return proxyToBackend(req, { path: `/api/auth/otp/${rest.join("/")}`, method: "POST" });
+}

--- a/src/app/api/matches/[id]/pick/route.ts
+++ b/src/app/api/matches/[id]/pick/route.ts
@@ -1,37 +1,12 @@
-import { revalidateTag } from "next/cache";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
 import { MATCHES_CACHE_TAG } from "@/features/schedule/api/matches";
 
-const UPSTREAM = process.env.BACKEND_API_URL;
+import { proxyToBackend } from "../../../_lib/proxy";
 
 // Proxies the upstream PUT and busts the matches fetch cache on success so the
-// schedule RSC reflects the new pick on the next render
+// schedule RSC reflects the new pick on the next render.
 export async function PUT(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
   const { id } = await ctx.params;
-  const auth = req.headers.get("authorization");
-
-  const response = await fetch(`${UPSTREAM}/api/matches/${id}/pick`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      ...(auth ? { Authorization: auth } : {}),
-    },
-    body: await req.text(),
-  });
-
-  if (response.ok) {
-    // `{ expire: 0 }` forces immediate expiry
-    revalidateTag(MATCHES_CACHE_TAG, { expire: 0 });
-  }
-
-  if (response.status === 204 || response.status === 205 || response.status === 304) {
-    return new NextResponse(null, { status: response.status });
-  }
-
-  const body = await response.text();
-  return new NextResponse(body, {
-    status: response.status,
-    headers: { "Content-Type": response.headers.get("content-type") ?? "application/json" },
-  });
+  return proxyToBackend(req, { path: `/api/matches/${id}/pick`, method: "PUT", revalidate: [MATCHES_CACHE_TAG] });
 }

--- a/src/app/api/pickems/best-thirds/route.ts
+++ b/src/app/api/pickems/best-thirds/route.ts
@@ -1,31 +1,9 @@
-import { revalidateTag } from "next/cache";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
 import { PICKEMS_CACHE_TAG } from "@/features/pickems/api/pickems";
 
-const UPSTREAM = process.env.BACKEND_API_URL;
+import { proxyToBackend } from "../../_lib/proxy";
 
 export async function PUT(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-
-  const response = await fetch(`${UPSTREAM}/api/pickems/best-thirds`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      ...(auth ? { Authorization: auth } : {}),
-    },
-    body: await req.text(),
-  });
-
-  if (response.ok) revalidateTag(PICKEMS_CACHE_TAG, { expire: 0 });
-
-  if (response.status === 204 || response.status === 205 || response.status === 304) {
-    return new NextResponse(null, { status: response.status });
-  }
-
-  const body = await response.text();
-  return new NextResponse(body, {
-    status: response.status,
-    headers: { "Content-Type": response.headers.get("content-type") ?? "application/json" },
-  });
+  return proxyToBackend(req, { path: "/api/pickems/best-thirds", method: "PUT", revalidate: [PICKEMS_CACHE_TAG] });
 }

--- a/src/app/api/pickems/bracket/route.ts
+++ b/src/app/api/pickems/bracket/route.ts
@@ -1,31 +1,9 @@
-import { revalidateTag } from "next/cache";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
 import { PICKEMS_CACHE_TAG } from "@/features/pickems/api/pickems";
 
-const UPSTREAM = process.env.BACKEND_API_URL;
+import { proxyToBackend } from "../../_lib/proxy";
 
 export async function PUT(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-
-  const response = await fetch(`${UPSTREAM}/api/pickems/bracket`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      ...(auth ? { Authorization: auth } : {}),
-    },
-    body: await req.text(),
-  });
-
-  if (response.ok) revalidateTag(PICKEMS_CACHE_TAG, { expire: 0 });
-
-  if (response.status === 204 || response.status === 205 || response.status === 304) {
-    return new NextResponse(null, { status: response.status });
-  }
-
-  const body = await response.text();
-  return new NextResponse(body, {
-    status: response.status,
-    headers: { "Content-Type": response.headers.get("content-type") ?? "application/json" },
-  });
+  return proxyToBackend(req, { path: "/api/pickems/bracket", method: "PUT", revalidate: [PICKEMS_CACHE_TAG] });
 }

--- a/src/app/api/pickems/groups/route.ts
+++ b/src/app/api/pickems/groups/route.ts
@@ -1,31 +1,9 @@
-import { revalidateTag } from "next/cache";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
 import { PICKEMS_CACHE_TAG } from "@/features/pickems/api/pickems";
 
-const UPSTREAM = process.env.BACKEND_API_URL;
+import { proxyToBackend } from "../../_lib/proxy";
 
 export async function PUT(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-
-  const response = await fetch(`${UPSTREAM}/api/pickems/groups`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      ...(auth ? { Authorization: auth } : {}),
-    },
-    body: await req.text(),
-  });
-
-  if (response.ok) revalidateTag(PICKEMS_CACHE_TAG, { expire: 0 });
-
-  if (response.status === 204 || response.status === 205 || response.status === 304) {
-    return new NextResponse(null, { status: response.status });
-  }
-
-  const body = await response.text();
-  return new NextResponse(body, {
-    status: response.status,
-    headers: { "Content-Type": response.headers.get("content-type") ?? "application/json" },
-  });
+  return proxyToBackend(req, { path: "/api/pickems/groups", method: "PUT", revalidate: [PICKEMS_CACHE_TAG] });
 }

--- a/src/features/awards/components/AwardsCrossSell.tsx
+++ b/src/features/awards/components/AwardsCrossSell.tsx
@@ -19,9 +19,9 @@ export function AwardsCrossSell({ isLocked = false }: Props) {
   const t = useTranslations("awards.crossSell");
 
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+    <div className="flex flex-col gap-3 rounded-xl border border-amber-300/70 bg-amber-100/80 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4 dark:border-amber-500/30 dark:bg-amber-500/15">
       <div className="flex items-start gap-3">
-        <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-600 dark:text-amber-300">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-amber-500/20 text-amber-600 dark:text-amber-300">
           <Trophy className="size-5" />
         </span>
         <div className="flex flex-col gap-0.5">

--- a/src/features/pickems/api/pickems.ts
+++ b/src/features/pickems/api/pickems.ts
@@ -1,4 +1,5 @@
 import { api } from "@/shared/lib/api/client";
+import { ApiClientError } from "@/shared/lib/api/errors";
 
 import type { SaveBestThirdsPayload, SaveBracketPicksPayload, SaveGroupPicksPayload, UserPickem } from "../types/pickems.types";
 
@@ -17,7 +18,9 @@ export async function fetchPickems(): Promise<UserPickem> {
 async function putPickem<T>(endpoint: string, body: T): Promise<UserPickem> {
   const res = await api.put<UserPickem>(endpoint, body, { authenticated: true });
   if (!res.success || !res.data) {
-    throw new Error(res.error?.message ?? "Failed to save");
+    // Preserve the backend's code + per-field detail so callers can log exactly
+    // what was rejected (e.g. bracket VALIDATION_FAILED → fields.bracket_picks).
+    throw new ApiClientError(res.error?.code ?? "UNKNOWN_ERROR", res.error?.message ?? "Failed to save", res.error?.fields);
   }
 
   return res.data;

--- a/src/features/pickems/components/PickemsView.tsx
+++ b/src/features/pickems/components/PickemsView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -42,6 +42,19 @@ export function PickemsView({ initialData, userId }: Props) {
   const groupsSave = useSaveGroups(userId);
   const bestThirdsSave = useSaveBestThirds(userId);
   const [navigating, setNavigating] = useState(false);
+
+  // Each step is its own screen — land at the top when moving between them
+  // (e.g. Continue from groups → best thirds → bracket) so the new step's header
+  // is in view rather than wherever the previous step was scrolled. Skips the
+  // first render so a deep-linked step isn't yanked to the top on load.
+  const isInitialStep = useRef(true);
+  useEffect(() => {
+    if (isInitialStep.current) {
+      isInitialStep.current = false;
+      return;
+    }
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [step]);
 
   // When the pickem is locked the server is read-only; localStorage drafts can
   // never sync, so ignore them and project against the server-saved state only

--- a/src/features/pickems/components/StepBracket.tsx
+++ b/src/features/pickems/components/StepBracket.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -8,7 +8,7 @@ import { useBracketDraft } from "../hooks/useBracketDraft";
 import { useSubmitBracket } from "../hooks/useSubmitBracket";
 import { STAGE_MATCH_IDS, STAGES, TOTAL_BRACKET_PICKS } from "../lib/bracketStructure";
 import { prevStep } from "../lib/pickemStep";
-import { findChampion, projectBracket } from "../lib/projectBracket";
+import { bracketSignature, findChampion, projectBracket } from "../lib/projectBracket";
 import type { BracketDraft, BracketStageCode, PickemProgress, PickemStep, UserPickem } from "../types/pickems.types";
 
 import { BracketDesktop } from "./BracketDesktop";
@@ -21,6 +21,10 @@ import { PickemsStepper } from "./PickemsStepper";
 
 // Stable reference for "no local draft" — keeps useMemo cached when locked.
 const EMPTY_DRAFT: BracketDraft = {};
+
+// Debounce before auto-saving a complete board, so rapid edits (e.g. flipping
+// the champion a few times) collapse into a single PUT instead of one each.
+const AUTO_SAVE_DELAY_MS = 1000;
 
 type Props = {
   data: UserPickem;
@@ -58,6 +62,29 @@ export function StepBracket({ data, step, onStep, progress, canNavigateTo, userI
   const pickedCount = projected.reduce((n, slot) => (slot.picked_team ? n + 1 : n), 0);
   const isReady = pickedCount === TOTAL_BRACKET_PICKS;
 
+  // Auto-save: desktop users scroll past the header Save and forget to commit, so
+  // once the board is complete we push it for them. We save only when the
+  // projected board differs from what's already on the server, debounced to batch
+  // rapid edits. `lastAutoSaved` holds the last signature we attempted: after the
+  // optimistic update it equals the server's, so success goes quiet; after an
+  // error the rollback makes it differ again, but the guard stops us re-firing the
+  // same failed payload (the Save button remains for a manual retry). Any *new*
+  // edit changes the signature and re-enables auto-save.
+  const savedSignature = useMemo(() => bracketSignature(data.bracket), [data.bracket]);
+  const projectedSignature = useMemo(() => bracketSignature(projected), [projected]);
+  const lastAutoSaved = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (data.is_locked || !isReady || isSubmitting) return;
+    if (projectedSignature === savedSignature) return; // already committed
+    if (projectedSignature === lastAutoSaved.current) return; // don't re-fire a failed payload
+    const id = window.setTimeout(() => {
+      lastAutoSaved.current = projectedSignature;
+      submit(projected);
+    }, AUTO_SAVE_DELAY_MS);
+    return () => window.clearTimeout(id);
+  }, [data.is_locked, isReady, isSubmitting, projectedSignature, savedSignature, projected, submit]);
+
   const projectedById = useMemo(() => new Map(projected.map((slot) => [slot.match_id, slot] as const)), [projected]);
   const stageStats = useMemo(() => {
     const ids = STAGE_MATCH_IDS[activeStage];
@@ -87,7 +114,7 @@ export function StepBracket({ data, step, onStep, progress, canNavigateTo, userI
         loading: isSubmitting,
         helperText,
         helperTone: isReady ? "ready" : undefined,
-        onClick: () => submit(draft),
+        onClick: () => submit(projected),
       };
 
   // Per-stage mobile CTA: a "Next: <round>" button gated on the current stage
@@ -118,7 +145,7 @@ export function StepBracket({ data, step, onStep, progress, canNavigateTo, userI
           loading: isSubmitting,
           helperText,
           helperTone: isReady ? "ready" : undefined,
-          onClick: () => submit(draft),
+          onClick: () => submit(projected),
         };
 
   const rightSlot = (

--- a/src/features/pickems/hooks/usePickemMutation.ts
+++ b/src/features/pickems/hooks/usePickemMutation.ts
@@ -4,6 +4,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
+import { ApiClientError } from "@/shared/lib/api/errors";
+
 import { PICKEMS_QUERY_KEY } from "../api/pickems";
 import { countClearedPicks } from "../lib/diffInvalidation";
 import type { UserPickem } from "../types/pickems.types";
@@ -42,8 +44,13 @@ export function usePickemMutation<TInput>({
       if (previous) qc.setQueryData<UserPickem>(PICKEMS_QUERY_KEY, applyOptimistic(previous, input));
       return { previous };
     },
-    onError: (_err, _input, ctx) => {
+    onError: (err, _input, ctx) => {
       if (ctx?.previous) qc.setQueryData(PICKEMS_QUERY_KEY, ctx.previous);
+      // Surface the backend's rejection detail (code + per-field validation) so a
+      // future failure is diagnosable from the console instead of just a toast.
+      // Intentionally logs in production — this exists to diagnose live rejections.
+      // eslint-disable-next-line no-console -- intentional diagnostic sink
+      if (err instanceof ApiClientError) console.warn("Pickem save rejected:", err.code, err.fields);
       toast.error(t(errorMessageKey));
     },
     onSuccess: (response, _input, ctx) => {

--- a/src/features/pickems/hooks/useSubmitBracket.ts
+++ b/src/features/pickems/hooks/useSubmitBracket.ts
@@ -1,13 +1,17 @@
 "use client";
 
 import { useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 import { saveBracketPicks } from "../api/pickems";
-import type { BracketDraft, SaveBracketPicksPayload } from "../types/pickems.types";
+import { TOTAL_BRACKET_PICKS } from "../lib/bracketStructure";
+import type { BracketMatchSlot, SaveBracketPicksPayload } from "../types/pickems.types";
 
 import { usePickemMutation } from "./usePickemMutation";
 
 export function useSubmitBracket() {
+  const tToasts = useTranslations("pickems.toasts");
   const mutation = usePickemMutation<SaveBracketPicksPayload>({
     mutationFn: saveBracketPicks,
     applyOptimistic: (prev, input) => {
@@ -27,15 +31,23 @@ export function useSubmitBracket() {
     errorMessageKey: "submitFailed",
   });
 
+  // Build the payload from the *projected* board — the same array the Submit
+  // gate counts — not the local draft. The draft only holds this device's edits
+  // and omits picks that resolve from the server's committed state, so sending
+  // it can ship <32 picks while the UI reads 32/32 (backend rejects on len=32).
   const submit = useCallback(
-    (draft: BracketDraft) => {
-      const bracket_picks = Object.entries(draft).map(([matchId, fifaCode]) => ({
-        match_id: Number(matchId),
-        team_fifa_code: fifaCode,
-      }));
+    (projected: BracketMatchSlot[]) => {
+      const bracket_picks = projected.filter((slot) => slot.picked_team).map((slot) => ({ match_id: slot.match_id, team_fifa_code: slot.picked_team!.fifa_code }));
+      // Defense-in-depth: the backend requires exactly 32 picks. The Submit button
+      // is already gated on a full board, but never fire an incomplete request —
+      // catch it here with a clear message instead of a generic "submit failed".
+      if (bracket_picks.length !== TOTAL_BRACKET_PICKS) {
+        toast.error(tToasts("pickAllBracketFirst"));
+        return;
+      }
       mutation.mutate({ bracket_picks });
     },
-    [mutation]
+    [mutation, tToasts]
   );
 
   return { submit, isSubmitting: mutation.isPending, isSuccess: mutation.isSuccess, isError: mutation.isError };

--- a/src/features/pickems/lib/projectBracket.ts
+++ b/src/features/pickems/lib/projectBracket.ts
@@ -65,7 +65,12 @@ export function projectBracket(serverBracket: BracketMatchSlot[], draft: Bracket
     if (draftCode) {
       if (home?.fifa_code === draftCode) picked = home;
       else if (away?.fifa_code === draftCode) picked = away;
-    } else if (slot.picked_team) {
+    } else if (slot.picked_team && (home?.fifa_code === slot.picked_team.fifa_code || away?.fifa_code === slot.picked_team.fifa_code)) {
+      // Only keep the server's committed pick when it's still one of the
+      // locally-computed sides. Changing an upstream pick shifts this slot's
+      // home/away, which can leave the server pick referencing a team that no
+      // longer plays here — counting it would read as "picked" while the card
+      // shows nothing, and submitting it would be rejected (INVALID_BRACKET_PICK).
       picked = slot.picked_team;
     }
 
@@ -79,6 +84,17 @@ export function projectBracket(serverBracket: BracketMatchSlot[], draft: Bracket
 
 export function findChampion(bracket: BracketMatchSlot[]): Team | null {
   return bracket.find((slot) => slot.stage_code === "final")?.picked_team ?? null;
+}
+
+/**
+ * Stable string identity of a bracket's picks (one `matchId:fifaCode` per slot,
+ * empty when unpicked). Used to tell whether the locally-projected board differs
+ * from what's already committed on the server — i.e. whether there's anything to
+ * auto-save. Both inputs come from the same server array order, so a plain map is
+ * order-stable; no sort needed.
+ */
+export function bracketSignature(bracket: BracketMatchSlot[]): string {
+  return bracket.map((slot) => `${slot.match_id}:${slot.picked_team?.fifa_code ?? ""}`).join(",");
 }
 
 /**

--- a/src/i18n/messages/pickems/en.json
+++ b/src/i18n/messages/pickems/en.json
@@ -86,6 +86,7 @@
     "submitFailed": "Could not submit your bracket. Try again.",
     "lockAllGroupsFirst": "Lock all 12 groups before continuing",
     "selectAllThirdsFirst": "Pick all 8 best thirds before continuing",
-    "finishRoundFirst": "Finish this round before continuing"
+    "finishRoundFirst": "Finish this round before continuing",
+    "pickAllBracketFirst": "Pick all 32 winners before submitting"
   }
 }

--- a/src/i18n/messages/pickems/es.json
+++ b/src/i18n/messages/pickems/es.json
@@ -86,6 +86,7 @@
     "submitFailed": "No se pudo enviar tu llave. Inténtalo de nuevo.",
     "lockAllGroupsFirst": "Confirma los 12 grupos antes de continuar",
     "selectAllThirdsFirst": "Elige los 8 mejores terceros antes de continuar",
-    "finishRoundFirst": "Termina esta ronda antes de continuar"
+    "finishRoundFirst": "Termina esta ronda antes de continuar",
+    "pickAllBracketFirst": "Elige los 32 ganadores antes de guardar tus picks"
   }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,6 +6,7 @@ import createMiddleware from "next-intl/middleware";
 import { routing, type Locale } from "@/i18n/routing";
 import { env } from "@/lib/env";
 import { HARD_AUTH_FAILURE_CODES } from "@/shared/lib/api/errors";
+import { forwardedClientHeaders } from "@/shared/lib/api/forwarded-headers";
 import { isTokenStale } from "@/shared/lib/api/jwt";
 
 // Authenticated users are redirected away from these routes (locale-stripped paths).
@@ -142,7 +143,7 @@ export default async function proxy(req: NextRequest) {
     if (!refreshToken) {
       if (isProtectedPath(path)) return expiredSessionRedirect(localized("/login"));
     } else if (isTokenStale(accessToken)) {
-      const refreshed = await refreshUpstream(refreshToken);
+      const refreshed = await refreshUpstream(refreshToken, req);
       if (refreshed === "hard-failure") return expiredSessionRedirect(localized("/login"));
 
       // Transient failure: let it through; the RSC hits a 401 and redirects itself.
@@ -163,11 +164,12 @@ export const config = {
 
 type RefreshSuccess = { accessToken: string; expiresAt: string; refreshToken: string; expires?: Date };
 
-async function refreshUpstream(refreshToken: string): Promise<RefreshSuccess | "hard-failure" | null> {
+async function refreshUpstream(refreshToken: string, req: NextRequest): Promise<RefreshSuccess | "hard-failure" | null> {
   try {
     const response = await fetch(`${process.env.BACKEND_API_URL}/api/auth/token/refresh`, {
       method: "POST",
       headers: {
+        ...forwardedClientHeaders(req),
         Cookie: `${REFRESH_COOKIE}=${refreshToken}`,
         "X-Refresh-Source": "middleware",
       },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,7 @@ import createMiddleware from "next-intl/middleware";
 import { routing, type Locale } from "@/i18n/routing";
 import { env } from "@/lib/env";
 import { HARD_AUTH_FAILURE_CODES } from "@/shared/lib/api/errors";
-import { forwardedClientHeaders } from "@/shared/lib/api/forwarded-headers";
+import { forwardedClientHeaders, trustedClientIpHeaders } from "@/shared/lib/api/forwarded-headers";
 import { isTokenStale } from "@/shared/lib/api/jwt";
 
 // Authenticated users are redirected away from these routes (locale-stripped paths).
@@ -66,6 +66,18 @@ function maintenanceResponse(req: NextRequest): NextResponse | null {
   return res;
 }
 
+function apiPassthrough(req: NextRequest): NextResponse {
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.delete("x-client-ip");
+  requestHeaders.delete("x-ip-forward-secret");
+
+  for (const [key, value] of Object.entries(trustedClientIpHeaders(req))) {
+    requestHeaders.set(key, value);
+  }
+
+  return NextResponse.next({ request: { headers: requestHeaders } });
+}
+
 function isPrefetch(req: NextRequest): boolean {
   return req.headers.has("next-router-prefetch") || req.headers.get("sec-purpose")?.includes("prefetch") === true || req.headers.get("purpose") === "prefetch";
 }
@@ -107,8 +119,9 @@ export default async function proxy(req: NextRequest) {
   if (maintenance) return maintenance;
 
   // API routes only need the maintenance gate above; the locale/auth pipeline below
-  // is page-oriented and would mangle them, so let them fall through to the rewrites.
-  if (req.nextUrl.pathname.startsWith("/api/")) return NextResponse.next();
+  // is page-oriented and would mangle them, so let them fall through to the rewrites —
+  // after stamping the trusted client-IP headers the rewrite proxy carries to the API.
+  if (req.nextUrl.pathname.startsWith("/api/")) return apiPassthrough(req);
 
   // 1. Locale routing first: handles prefixing, the locale cookie, hreflang headers,
   //    and any locale redirect (e.g. a non-default cookie on the unprefixed path).

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,7 @@ import createMiddleware from "next-intl/middleware";
 import { routing, type Locale } from "@/i18n/routing";
 import { env } from "@/lib/env";
 import { HARD_AUTH_FAILURE_CODES } from "@/shared/lib/api/errors";
-import { forwardedClientHeaders, trustedClientIpHeaders } from "@/shared/lib/api/forwarded-headers";
+import { forwardedClientHeaders } from "@/shared/lib/api/forwarded-headers";
 import { isTokenStale } from "@/shared/lib/api/jwt";
 
 // Authenticated users are redirected away from these routes (locale-stripped paths).
@@ -66,18 +66,6 @@ function maintenanceResponse(req: NextRequest): NextResponse | null {
   return res;
 }
 
-function apiPassthrough(req: NextRequest): NextResponse {
-  const requestHeaders = new Headers(req.headers);
-  requestHeaders.delete("x-client-ip");
-  requestHeaders.delete("x-ip-forward-secret");
-
-  for (const [key, value] of Object.entries(trustedClientIpHeaders(req))) {
-    requestHeaders.set(key, value);
-  }
-
-  return NextResponse.next({ request: { headers: requestHeaders } });
-}
-
 function isPrefetch(req: NextRequest): boolean {
   return req.headers.has("next-router-prefetch") || req.headers.get("sec-purpose")?.includes("prefetch") === true || req.headers.get("purpose") === "prefetch";
 }
@@ -119,9 +107,9 @@ export default async function proxy(req: NextRequest) {
   if (maintenance) return maintenance;
 
   // API routes only need the maintenance gate above; the locale/auth pipeline below
-  // is page-oriented and would mangle them, so let them fall through to the rewrites —
-  // after stamping the trusted client-IP headers the rewrite proxy carries to the API.
-  if (req.nextUrl.pathname.startsWith("/api/")) return apiPassthrough(req);
+  // is page-oriented and would mangle them, so let them fall through to the route
+  // handlers / rewrites that proxy to the backend.
+  if (req.nextUrl.pathname.startsWith("/api/")) return NextResponse.next();
 
   // 1. Locale routing first: handles prefixing, the locale cookie, hreflang headers,
   //    and any locale redirect (e.g. a non-default cookie on the unprefixed path).

--- a/src/shared/components/ui/sonner.tsx
+++ b/src/shared/components/ui/sonner.tsx
@@ -11,6 +11,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
+      richColors
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,

--- a/src/shared/lib/api/errors.ts
+++ b/src/shared/lib/api/errors.ts
@@ -1,3 +1,5 @@
+import type { ApiErrorField } from "./types";
+
 export const API_ERROR_CODES = {
   NETWORK_ERROR: "NETWORK_ERROR",
   UNAUTHENTICATED: "UNAUTHENTICATED",
@@ -21,10 +23,12 @@ export const HARD_AUTH_FAILURE_CODES: ReadonlySet<string> = new Set([
 
 export class ApiClientError extends Error {
   readonly code: string;
-  constructor(code: string, message: string) {
+  readonly fields?: Record<string, ApiErrorField>;
+  constructor(code: string, message: string, fields?: Record<string, ApiErrorField>) {
     super(message);
     this.name = "ApiClientError";
     this.code = code;
+    this.fields = fields;
   }
 }
 

--- a/src/shared/lib/api/forwarded-headers.ts
+++ b/src/shared/lib/api/forwarded-headers.ts
@@ -9,5 +9,19 @@ export function forwardedClientHeaders(req: NextRequest): Record<string, string>
   const forwardedFor = req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip");
   if (forwardedFor) headers["X-Forwarded-For"] = forwardedFor;
 
-  return headers;
+  return { ...headers, ...trustedClientIpHeaders(req) };
+}
+
+export function clientIpFromRequest(req: NextRequest): string | null {
+  const forwardedFor = req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip");
+  const first = forwardedFor?.split(",")[0]?.trim();
+  return first || null;
+}
+
+export function trustedClientIpHeaders(req: NextRequest): Record<string, string> {
+  const clientIp = clientIpFromRequest(req);
+  const secret = process.env.IP_FORWARD_SECRET;
+  if (!clientIp || !secret) return {};
+
+  return { "X-Client-IP": clientIp, "X-IP-Forward-Secret": secret };
 }

--- a/src/shared/lib/api/forwarded-headers.ts
+++ b/src/shared/lib/api/forwarded-headers.ts
@@ -1,25 +1,28 @@
 import type { NextRequest } from "next/server";
 
+type HeaderReader = Pick<Headers, "get">;
+
 export function forwardedClientHeaders(req: NextRequest): Record<string, string> {
+  const src = req.headers;
   const headers: Record<string, string> = {};
 
-  const userAgent = req.headers.get("user-agent");
+  const userAgent = src.get("user-agent");
   if (userAgent) headers["User-Agent"] = userAgent;
 
-  const forwardedFor = req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip");
+  const forwardedFor = src.get("x-forwarded-for") ?? src.get("x-real-ip");
   if (forwardedFor) headers["X-Forwarded-For"] = forwardedFor;
 
-  return { ...headers, ...trustedClientIpHeaders(req) };
+  return { ...headers, ...trustedClientIpHeaders(src) };
 }
 
-export function clientIpFromRequest(req: NextRequest): string | null {
-  const forwardedFor = req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip");
+export function clientIpFromHeaders(src: HeaderReader): string | null {
+  const forwardedFor = src.get("x-forwarded-for") ?? src.get("x-real-ip");
   const first = forwardedFor?.split(",")[0]?.trim();
   return first || null;
 }
 
-export function trustedClientIpHeaders(req: NextRequest): Record<string, string> {
-  const clientIp = clientIpFromRequest(req);
+export function trustedClientIpHeaders(src: HeaderReader): Record<string, string> {
+  const clientIp = clientIpFromHeaders(src);
   const secret = process.env.IP_FORWARD_SECRET;
   if (!clientIp || !secret) return {};
 

--- a/src/shared/lib/api/forwarded-headers.ts
+++ b/src/shared/lib/api/forwarded-headers.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from "next/server";
+
+export function forwardedClientHeaders(req: NextRequest): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  const userAgent = req.headers.get("user-agent");
+  if (userAgent) headers["User-Agent"] = userAgent;
+
+  const forwardedFor = req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip");
+  if (forwardedFor) headers["X-Forwarded-For"] = forwardedFor;
+
+  return headers;
+}

--- a/src/shared/lib/api/server.ts
+++ b/src/shared/lib/api/server.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { headers as getRequestHeaders } from "next/headers";
 import { getServerSession } from "next-auth";
 import { getLocale } from "next-intl/server";
 
@@ -9,7 +10,16 @@ import { env } from "@/lib/env";
 
 import { logger } from "../logger";
 
+import { trustedClientIpHeaders } from "./forwarded-headers";
 import { ApiError, ApiResponse } from "./types";
+
+async function clientIpHeaders(): Promise<Record<string, string>> {
+  try {
+    return trustedClientIpHeaders(await getRequestHeaders());
+  } catch {
+    return {};
+  }
+}
 
 type RequestOptions = Omit<RequestInit, "method" | "body"> & {
   authenticated?: boolean;
@@ -27,6 +37,8 @@ async function request<T>(endpoint: string, options: RequestOptions = { method: 
   const url = `${env.BACKEND_API_URL}${endpoint}`;
   const headers = new Headers(options.headers as HeadersInit | undefined);
   if (!headers.has("Content-Type")) headers.set("Content-Type", "application/json");
+
+  for (const [key, value] of Object.entries(await clientIpHeaders())) headers.set(key, value);
 
   if (authenticated) {
     const session = await getServerSession(authOptions);


### PR DESCRIPTION
## Release v1.2.2

Hardens API request handling — routes now proxy through a dedicated helper with trusted client-IP forwarding.

### Highlights
- Forward trusted client IP headers to the upstream API (#87)

### Fixes
- Replace direct fetch calls with a shared proxy function for consistent routing (#89)
- Introduce dedicated proxy routes and drop outdated rewrites (#88)
- Forward client headers and improve error handling (#86)