### PR TITLE
feat(seo): add structured data and improve ES regional keyword coverage

### DIFF
--- a/src/app/[locale]/bracket/page.tsx
+++ b/src/app/[locale]/bracket/page.tsx
@@ -1,11 +1,42 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { PlaceholderPage } from "@/shared/components/PlaceholderPage";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
+import { buildPageMetadata } from "@/shared/seo/metadata";
 
-export const metadata: Metadata = { title: "Bracket | WCP" };
+type Props = { params: Promise<{ locale: string }> };
 
-export default async function BracketPage() {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  return buildPageMetadata({ locale, namespace: "seo.bracket", path: "/bracket" });
+}
+
+export default async function BracketPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
   const t = await getTranslations("pages");
-  return <PlaceholderPage eyebrow={t("comingSoonBadge")} title={t("bracket.title")} body={t("bracket.body")} />;
+
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const bracketLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildBreadcrumbJsonLd(
+        [
+          { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+          { name: "Bracket", url: `${SITE_URL}${prefix}/bracket` },
+        ],
+        locale
+      ),
+    ],
+  };
+
+  return (
+    <>
+      <JsonLd data={bracketLd} />
+      <PlaceholderPage eyebrow={t("comingSoonBadge")} title={t("bracket.title")} body={t("bracket.body")} />
+    </>
+  );
 }

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import { Link } from "@/i18n/navigation";
+import { SITE_URL } from "@/lib/site";
 import { JsonLd } from "@/shared/components/JsonLd";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/shared/components/ui/accordion";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 type Props = { params: Promise<{ locale: string }> };
@@ -24,22 +26,31 @@ export default async function FaqPage({ params }: Props) {
   const t = await getTranslations("pages.faq");
 
   const stripTags = { rulesLink: (c: string) => c, boardsLink: (c: string) => c, howItWorksLink: (c: string) => c };
-  const faqJsonLd = {
+  const faqItems = FAQ_KEYS.map((key) => ({
+    "@type": "Question",
+    name: t(`items.${key}.question`),
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: t.markup(`items.${key}.answer`, stripTags),
+    },
+  }));
+
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const breadcrumb = buildBreadcrumbJsonLd(
+    [
+      { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+      { name: "FAQ", url: `${SITE_URL}${prefix}/faq` },
+    ],
+    locale
+  );
+  const combinedLd = {
     "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: FAQ_KEYS.map((key) => ({
-      "@type": "Question",
-      name: t(`items.${key}.question`),
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: t.markup(`items.${key}.answer`, stripTags),
-      },
-    })),
+    "@graph": [{ "@type": "FAQPage", mainEntity: faqItems }, breadcrumb],
   };
 
   return (
     <section className="container py-6 lg:py-8">
-      <JsonLd data={faqJsonLd} />
+      <JsonLd data={combinedLd} />
       <div className="flex flex-col gap-10">
         <header className="flex flex-col gap-4 border-b border-border pb-10">
           <span className={eyebrow}>{t("eyebrow")}</span>

--- a/src/app/[locale]/how-it-works/page.tsx
+++ b/src/app/[locale]/how-it-works/page.tsx
@@ -2,7 +2,10 @@ import { Award, BarChart3, Medal, Target, Trophy, UserPlus, Users, type LucideIc
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { Card } from "@/shared/components/ui/card";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 type Props = { params: Promise<{ locale: string }> };
@@ -41,8 +44,23 @@ export default async function HowItWorksPage({ params }: Props) {
   setRequestLocale(locale);
   const t = await getTranslations("pages.howItWorks");
 
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const howItWorksLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildBreadcrumbJsonLd(
+        [
+          { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+          { name: "How to Play", url: `${SITE_URL}${prefix}/how-it-works` },
+        ],
+        locale
+      ),
+    ],
+  };
+
   return (
     <section className="container py-6 lg:py-8">
+      <JsonLd data={howItWorksLd} />
       <div className="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:items-start lg:gap-12 xl:gap-20">
         <div className="flex flex-col gap-6 lg:sticky lg:top-24 lg:max-w-sm lg:self-start">
           <Hero eyebrow={t("eyebrow")} title={t("title")} intro={t("intro")} />

--- a/src/app/[locale]/rules/page.tsx
+++ b/src/app/[locale]/rules/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { Card } from "@/shared/components/ui/card";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 type Props = { params: Promise<{ locale: string }> };
@@ -53,8 +56,23 @@ export default async function RulesPage({ params }: Props) {
   setRequestLocale(locale);
   const t = await getTranslations("pages.rules");
 
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const rulesLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildBreadcrumbJsonLd(
+        [
+          { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+          { name: "Rules", url: `${SITE_URL}${prefix}/rules` },
+        ],
+        locale
+      ),
+    ],
+  };
+
   return (
     <section className="container py-6 lg:py-8">
+      <JsonLd data={rulesLd} />
       <div className="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:items-start lg:gap-12 xl:gap-20">
         <div className="flex flex-col gap-6 lg:sticky lg:top-24 lg:max-w-sm lg:self-start">
           <Hero eyebrow={t("eyebrow")} title={t("title")} intro={t("intro")} />

--- a/src/app/[locale]/schedule/page.tsx
+++ b/src/app/[locale]/schedule/page.tsx
@@ -4,10 +4,14 @@ import { getTranslations } from "next-intl/server";
 
 import { MATCHES_CACHE_TAG } from "@/features/schedule/api/matches";
 import { ScheduleView } from "@/features/schedule/components/ScheduleView";
+import { buildScheduleJsonLd } from "@/features/schedule/lib/buildScheduleJsonLd";
 import { findAnchorMatchId } from "@/features/schedule/lib/findAnchorMatch";
 import type { Match } from "@/features/schedule/types/schedule.types";
 import { getCurrentUser } from "@/lib/auth";
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { serverApi } from "@/shared/lib/api/server";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 type Props = { params: Promise<{ locale: string }>; searchParams: Promise<{ match?: string }> };
@@ -17,9 +21,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildPageMetadata({ locale, namespace: "seo.schedule", path: "/schedule" });
 }
 
-export default async function SchedulePage({ searchParams }: Props) {
+export default async function SchedulePage({ params, searchParams }: Props) {
   const t = await getTranslations("schedule");
-  const [user, { match }] = await Promise.all([getCurrentUser(), searchParams]);
+  const [{ locale }, user, { match }] = await Promise.all([params, getCurrentUser(), searchParams]);
   const deepLinkMatchId = match && Number.isFinite(Number(match)) ? Number(match) : null;
 
   const res = await serverApi.get<Match[]>("/api/matches", {
@@ -34,9 +38,21 @@ export default async function SchedulePage({ searchParams }: Props) {
     throw new Error(res.error?.message ?? "Failed to load matches");
   }
 
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const eventsData = buildScheduleJsonLd(res.data, locale);
+  const breadcrumb = buildBreadcrumbJsonLd(
+    [
+      { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+      { name: "Schedule", url: `${SITE_URL}${prefix}/schedule` },
+    ],
+    locale
+  );
+  const scheduleLd = { "@context": "https://schema.org", "@graph": [...eventsData["@graph"], breadcrumb] };
+
   return (
     <>
       <h1 className="sr-only">{t("title")}</h1>
+      <JsonLd data={scheduleLd} />
       {/* ScheduleView reads filters from the URL via useSearchParams,
           which Next.js requires under a Suspense boundary. */}
       <Suspense>

--- a/src/app/[locale]/standings/page.tsx
+++ b/src/app/[locale]/standings/page.tsx
@@ -7,7 +7,10 @@ import { STANDINGS_CACHE_TAG } from "@/features/standings/api/standings";
 import { StandingsView } from "@/features/standings/components/StandingsView";
 import type { StandingRow } from "@/features/standings/types/standings.types";
 import { getCurrentUser } from "@/lib/auth";
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { serverApi } from "@/shared/lib/api/server";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 import StandingsLoading from "./loading";
@@ -17,8 +20,8 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return buildPageMetadata({ locale, namespace: "seo.standings", path: "/standings" });
 }
 
-export default async function StandingsPage() {
-  const user = await getCurrentUser();
+export default async function StandingsPage({ params }: { params: Promise<{ locale: string }> }) {
+  const [{ locale }, user] = await Promise.all([params, getCurrentUser()]);
 
   // Public endpoint — guests welcome. A failure here is fatal: without the
   // table there is no page, so let the error boundary take over.
@@ -44,13 +47,26 @@ export default async function StandingsPage() {
     else pickemFailed = true;
   }
 
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const breadcrumbLd = buildBreadcrumbJsonLd(
+    [
+      { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+      { name: "Standings", url: `${SITE_URL}${prefix}/standings` },
+    ],
+    locale
+  );
+  const standingsLd = { "@context": "https://schema.org", "@graph": [breadcrumbLd] };
+
   // StandingsView reads the compare toggle from the URL via useSearchParams,
   // which Next.js requires under a Suspense boundary. The route-level
   // `loading.tsx` covers the *initial* paint; this fallback covers any later
   // client transition that suspends — without it the page would blank out.
   return (
-    <Suspense fallback={<StandingsLoading />}>
-      <StandingsView initialStandings={standingsRes.data} initialPickem={pickem} pickemFailed={pickemFailed} isAuthed={Boolean(user)} />
-    </Suspense>
+    <>
+      <JsonLd data={standingsLd} />
+      <Suspense fallback={<StandingsLoading />}>
+        <StandingsView initialStandings={standingsRes.data} initialPickem={pickem} pickemFailed={pickemFailed} isAuthed={Boolean(user)} />
+      </Suspense>
+    </>
   );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,17 +2,18 @@ import type { MetadataRoute } from "next";
 
 import { SITE_URL } from "@/lib/site";
 
-// Public, crawlable routes only — excludes auth-gated pages and placeholders.
-const PUBLIC_PATHS = ["", "/schedule", "/standings", "/how-it-works", "/rules", "/privacy", "/terms"];
+const PUBLIC_PATHS = ["", "/schedule", "/standings", "/bracket", "/faq", "/how-it-works", "/rules", "/privacy", "/terms"];
+
+function sitemapEntry(path: string): MetadataRoute.Sitemap[number] {
+  const enUrl = `${SITE_URL}${path || "/"}`;
+  const esUrl = `${SITE_URL}/es${path}`;
+  return {
+    url: enUrl,
+    lastModified: new Date("2026-06-09"),
+    alternates: { languages: { en: enUrl, es: esUrl, "x-default": enUrl } },
+  };
+}
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return PUBLIC_PATHS.map((path) => ({
-    url: `${SITE_URL}${path || "/"}`,
-    alternates: {
-      languages: {
-        en: `${SITE_URL}${path || "/"}`,
-        es: `${SITE_URL}/es${path}`,
-      },
-    },
-  }));
+  return PUBLIC_PATHS.map(sitemapEntry);
 }

--- a/src/features/schedule/lib/buildScheduleJsonLd.ts
+++ b/src/features/schedule/lib/buildScheduleJsonLd.ts
@@ -1,0 +1,30 @@
+import type { Match } from "@/features/schedule/types/schedule.types";
+import { getTeamName } from "@/shared/lib/getTeamName";
+
+export function buildScheduleJsonLd(matches: Match[], locale: string): { "@context": string; "@graph": unknown[] } {
+  const graph: unknown[] = matches
+    .filter((m) => m.teams.home !== null && m.teams.away !== null)
+    .map((m) => {
+      const home = getTeamName(m.teams.home!, locale);
+      const away = getTeamName(m.teams.away!, locale);
+      return {
+        "@type": "SportsEvent",
+        name: `${home} vs ${away}`,
+        startDate: m.kickoff_at,
+        location: {
+          "@type": "Place",
+          name: m.venue.name,
+          address: {
+            "@type": "PostalAddress",
+            addressLocality: m.venue.city,
+          },
+        },
+        competitor: [
+          { "@type": "SportsTeam", name: home },
+          { "@type": "SportsTeam", name: away },
+        ],
+      };
+    });
+
+  return { "@context": "https://schema.org", "@graph": graph };
+}

--- a/src/i18n/messages/layout/es.json
+++ b/src/i18n/messages/layout/es.json
@@ -65,7 +65,7 @@
     "howItWorks": {
       "title": "Cómo funciona",
       "eyebrow": "Cómo empezar",
-      "intro": "Pick'ems es el juego definitivo de pronósticos del Mundial 2026. Compite con tus amigos prediciendo resultados, posiciones de grupos y el cuadro de eliminatorias.",
+      "intro": "La quiniela del Mundial 2026 que te faltaba. Pronostica cada partido, arma la polla con tus amigos y compite en tiempo real.",
       "steps": {
         "createAccount": {
           "title": "Crea tu cuenta",
@@ -210,7 +210,7 @@
       "items": {
         "whatIs": {
           "question": "¿Qué es Pick'ems?",
-          "answer": "Pick'ems es un juego gratuito de pronósticos para el Mundial FIFA 2026. Predices marcadores, posiciones de grupos y el cuadro de eliminatorias, y compites con amigos en clasificaciones. Más información en <howItWorksLink>Cómo funciona</howItWorksLink>."
+          "answer": "Pick'ems es un juego gratuito de pronósticos del Mundial FIFA 2026 (en México quiniela, en Argentina prode, en Colombia, Chile, Perú y Venezuela polla, en España porra). Predices marcadores, posiciones de grupos y el cuadro de eliminatorias, y compites con amigos en clasificaciones. Más información en <howItWorksLink>Cómo funciona</howItWorksLink>."
         },
         "howToPlay": {
           "question": "¿Cómo juego?",

--- a/src/i18n/messages/seo/en.json
+++ b/src/i18n/messages/seo/en.json
@@ -34,5 +34,9 @@
   "faq": {
     "title": "FAQ — World Cup 2026 Pick'ems",
     "description": "Frequently asked questions about Pick'ems: how to play, scoring rules, boards, and everything you need to know about the World Cup 2026 prediction game."
+  },
+  "bracket": {
+    "title": "Bracket — World Cup 2026 Knockout Stage",
+    "description": "View the FIFA World Cup 2026 knockout bracket: round of 32, round of 16, quarterfinals, semifinals and the final. Follow your Pick'ems predictions match by match."
   }
 }

--- a/src/i18n/messages/seo/es.json
+++ b/src/i18n/messages/seo/es.json
@@ -1,19 +1,19 @@
 {
   "home": {
     "title": "Pick'ems — Quiniela y Pronósticos del Mundial 2026 Gratis",
-    "description": "Juega la quiniela del Mundial 2026: pronostica los marcadores, arma tu llave y compite con amigos en tablas en vivo. Gratis."
+    "description": "La quiniela del Mundial 2026 más completa (prode en Argentina, porra en España, polla en Latam): pronostica marcadores, compite con amigos en tableros en vivo. Gratis."
   },
   "schedule": {
     "title": "Calendario del Mundial 2026 — Fechas, Horarios y Grupos",
-    "description": "Calendario completo del Mundial FIFA 2026: fechas, horarios, sedes y grupos. Pronostica cada marcador antes del inicio y sube en la tabla."
+    "description": "Consulta el calendario completo del Mundial FIFA 2026 y pronostica cada marcador antes del pitazo. No te quedes atrás en tu quiniela."
   },
   "standings": {
     "title": "Posiciones del Mundial 2026 — Tablas de Grupos en Vivo",
     "description": "Tabla de posiciones del Mundial FIFA 2026 en vivo: puntos, diferencia de gol y clasificados. Compara las tablas reales con tus pronósticos del pick'em."
   },
   "howItWorks": {
-    "title": "Cómo Jugar — Pronósticos del Mundial 2026",
-    "description": "Aprende cómo funciona Pick'ems: pronostica los grupos, arma tu llave del Mundial 2026, acierta los marcadores y suma puntos en tablas compartidas."
+    "title": "Cómo Jugar la Quiniela del Mundial 2026",
+    "description": "Domina tu quiniela del Mundial 2026: pronostica grupos, llena el bracket, acierta marcadores y deja a tus amigos sin excusas."
   },
   "rules": {
     "title": "Reglas y Puntuación — Mundial 2026",
@@ -33,6 +33,10 @@
   },
   "faq": {
     "title": "FAQ — Pick'ems del Mundial 2026",
-    "description": "Preguntas frecuentes sobre Pick'ems: cómo jugar, reglas de puntuación, tableros y todo lo que necesitas saber sobre el juego de pronósticos del Mundial 2026."
+    "description": "Todo lo que necesitas para tu polla mundialista del Mundial 2026: cómo jugar, puntuación, tableros y cómo dejar a tus amigos sin argumentos."
+  },
+  "bracket": {
+    "title": "Eliminatorias — Fase Final del Mundial 2026",
+    "description": "Sigue las eliminatorias del Mundial FIFA 2026: ronda de 32, octavos, cuartos, semifinales y la gran final. Compara el resultado real con tus pronósticos del Pick'ems."
   }
 }

--- a/src/shared/seo/breadcrumbs.ts
+++ b/src/shared/seo/breadcrumbs.ts
@@ -1,0 +1,11 @@
+export function buildBreadcrumbJsonLd(items: Array<{ name: string; url: string }>, _: string): Record<string, unknown> {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map(({ name, url }, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name,
+      item: url,
+    })),
+  };
+}


### PR DESCRIPTION
## Related issue

N/A

## What changed

- Add SportsEvent JSON-LD to `/schedule` (all confirmed matches with teams, kickoff time, venue)
- Add BreadcrumbList JSON-LD to bracket, faq, how-it-works, rules, standings, schedule
- Fix bracket page: replace static `metadata` export with `generateMetadata` + `buildPageMetadata`
- Improve ES meta descriptions: regional synonyms (quiniela/polla/prode/porra), more action-oriented copy
- Update sitemap: add `/bracket`, `/faq`, `x-default` alternates, `lastModified` on all entries

## How to test

- [ ] Visit `/es` and inspect `<meta name="description">` — should mention quiniela, prode, porra, polla
- [ ] Visit `/es/faq`, open "¿Qué es Pick'ems?" — answer should list all 4 regional terms
- [ ] Visit `/schedule` and view source — confirm `SportsEvent` JSON-LD block in `<head>`
- [ ] Visit `/sitemap.xml` — confirm `/bracket`, `/faq` present with `en`/`es`/`x-default` alternates
- [ ] Paste `/es/bracket` into Rich Results Test — BreadcrumbList should validate