### PR TITLE
fix(pickems): discard stale local drafts when server state has changed

### DIFF
--- a/src/features/pickems/api/pickems.ts
+++ b/src/features/pickems/api/pickems.ts
@@ -1,6 +1,7 @@
 import { api } from "@/shared/lib/api/client";
 import { ApiClientError } from "@/shared/lib/api/errors";
 
+import { syncDraftBaseline } from "../lib/draftBaseline";
 import type { SaveBestThirdsPayload, SaveBracketPicksPayload, SaveGroupPicksPayload, UserPickem } from "../types/pickems.types";
 
 export const PICKEMS_QUERY_KEY = ["pickems"] as const;
@@ -12,6 +13,8 @@ export async function fetchPickems(): Promise<UserPickem> {
     throw new Error(res.error?.message ?? "Failed to load pickems");
   }
 
+  // Every fetch result is server truth — keep the draft-staleness baseline current.
+  syncDraftBaseline(res.data);
   return res.data;
 }
 

--- a/src/features/pickems/components/PickemsView.tsx
+++ b/src/features/pickems/components/PickemsView.tsx
@@ -8,6 +8,7 @@ import { AwardsCrossSell } from "@/features/awards/components/AwardsCrossSell";
 import { useHydrated } from "@/shared/hooks/useHydrated";
 
 import { useBracketDraft } from "../hooks/useBracketDraft";
+import { useDraftBaseline } from "../hooks/useDraftBaseline";
 import { usePickems } from "../hooks/usePickems";
 import { useSaveBestThirds } from "../hooks/useSaveBestThirds";
 import { useSaveGroups } from "../hooks/useSaveGroups";
@@ -36,6 +37,9 @@ const EMPTY_BRACKET_DRAFT: BracketDraft = {};
 export function PickemsView({ initialData, userId }: Props) {
   const hydrated = useHydrated();
   const tToasts = useTranslations("pickems.toasts");
+  // Must come before the draft hooks below — their localStorage reads validate
+  // drafts against this baseline, and layout effects run in declaration order.
+  useDraftBaseline(initialData);
   const { data = initialData } = usePickems(initialData);
   const [step, rawSetStep] = useStep();
   const { draft: bracketDraft, replaceDraft: replaceBracketDraft, isHydrated: bracketDraftHydrated } = useBracketDraft(userId);

--- a/src/features/pickems/hooks/useDraftBaseline.ts
+++ b/src/features/pickems/hooks/useDraftBaseline.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useIsomorphicLayoutEffect } from "@/shared/hooks/useIsomorphicLayoutEffect";
+
+import { PICKEMS_QUERY_KEY } from "../api/pickems";
+import { initDraftBaseline } from "../lib/draftBaseline";
+import type { UserPickem } from "../types/pickems.types";
+
+/**
+ * Seeds the draft-staleness baseline from the first server snapshot of the
+ * session. Must be the first draft hook PickemsView calls: the storage reads
+ * in useBracketDraft / useSaveGroups / useSaveBestThirds validate their drafts
+ * against this baseline, and layout effects run in declaration order. On the
+ * first mount the query cache is still the untouched server payload; later
+ * mounts are no-ops (the baseline then tracks fetch/mutation responses).
+ */
+export function useDraftBaseline(initialData: UserPickem): void {
+  const qc = useQueryClient();
+
+  useIsomorphicLayoutEffect(() => {
+    initDraftBaseline(qc.getQueryData<UserPickem>(PICKEMS_QUERY_KEY) ?? initialData);
+  }, [qc, initialData]);
+}

--- a/src/features/pickems/hooks/usePickemMutation.ts
+++ b/src/features/pickems/hooks/usePickemMutation.ts
@@ -8,6 +8,7 @@ import { ApiClientError } from "@/shared/lib/api/errors";
 
 import { PICKEMS_QUERY_KEY } from "../api/pickems";
 import { countClearedPicks } from "../lib/diffInvalidation";
+import { syncDraftBaseline } from "../lib/draftBaseline";
 import type { UserPickem } from "../types/pickems.types";
 
 type Options<TInput> = {
@@ -54,6 +55,10 @@ export function usePickemMutation<TInput>({
       toast.error(t(errorMessageKey));
     },
     onSuccess: (response, _input, ctx) => {
+      // The response is the new server truth — drafts written from here on are
+      // stamped against it, and older stamps become stale (see draftBaseline).
+      syncDraftBaseline(response);
+
       const current = qc.getQueryData<UserPickem>(PICKEMS_QUERY_KEY);
       if (current) {
         const merged = mergeServerResponse ? mergeServerResponse(current, response) : response;

--- a/src/features/pickems/lib/bestThirdsDraftStorage.ts
+++ b/src/features/pickems/lib/bestThirdsDraftStorage.ts
@@ -1,7 +1,15 @@
+import { getDraftBase } from "./draftBaseline";
+
 /** Ordered FIFA codes the user has marked as their best 3rd-place picks. */
 export type BestThirdsDraft = string[];
 
-const KEY_PREFIX = "wcp.pickems.bestThirdsDraft";
+// v2: draft wrapped in a `{ base, data }` envelope, where `base` is the
+// signature of the server state the draft was built on (see `draftBaseline`).
+// The bump makes any un-stamped draft fall out of scope — those carry no
+// recency information, so a stale one could clobber picks submitted from
+// another device.
+const KEY_PREFIX = "wcp.pickems.bestThirdsDraft.v2";
+const LEGACY_KEY_PREFIX = "wcp.pickems.bestThirdsDraft";
 
 export function bestThirdsDraftKey(userId: string | undefined): string {
   return `${KEY_PREFIX}.${userId ?? "anonymous"}`;
@@ -10,10 +18,22 @@ export function bestThirdsDraftKey(userId: string | undefined): string {
 export function readBestThirdsDraft(userId: string | undefined): BestThirdsDraft | null {
   if (typeof window === "undefined") return null;
   try {
+    window.localStorage.removeItem(`${LEGACY_KEY_PREFIX}.${userId ?? "anonymous"}`);
     const raw = window.localStorage.getItem(bestThirdsDraftKey(userId));
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed) && parsed.every((s) => typeof s === "string") ? (parsed as BestThirdsDraft) : null;
+    if (!parsed || typeof parsed !== "object") return null;
+    const { base, data } = parsed as { base?: unknown; data?: unknown };
+    if (typeof base !== "string" || !Array.isArray(data) || !data.every((s) => typeof s === "string")) return null;
+    // Built on a server state that has since changed (e.g. saved from another
+    // device) — the draft is stale and the server wins.
+    const currentBase = getDraftBase("thirds");
+    if (currentBase === null) return null;
+    if (base !== currentBase) {
+      window.localStorage.removeItem(bestThirdsDraftKey(userId));
+      return null;
+    }
+    return data as BestThirdsDraft;
   } catch {
     return null;
   }
@@ -21,8 +41,10 @@ export function readBestThirdsDraft(userId: string | undefined): BestThirdsDraft
 
 export function writeBestThirdsDraft(userId: string | undefined, draft: BestThirdsDraft): void {
   if (typeof window === "undefined") return;
+  const base = getDraftBase("thirds");
+  if (base === null) return; // no server state seen yet — nothing to stamp against
   try {
-    window.localStorage.setItem(bestThirdsDraftKey(userId), JSON.stringify(draft));
+    window.localStorage.setItem(bestThirdsDraftKey(userId), JSON.stringify({ base, data: draft }));
   } catch {
     // ignore — storage may be unavailable (private mode, quota, etc.)
   }

--- a/src/features/pickems/lib/bracketDraftStorage.ts
+++ b/src/features/pickems/lib/bracketDraftStorage.ts
@@ -1,6 +1,14 @@
 import type { BracketDraft } from "../types/pickems.types";
 
-const KEY_PREFIX = "wcp.pickems.bracketDraft";
+import { getDraftBase } from "./draftBaseline";
+
+// v2: draft wrapped in a `{ base, data }` envelope, where `base` is the
+// signature of the server state the draft was built on (see `draftBaseline`).
+// The bump makes any un-stamped draft fall out of scope — those carry no
+// recency information, so a stale one could clobber picks submitted from
+// another device.
+const KEY_PREFIX = "wcp.pickems.bracketDraft.v2";
+const LEGACY_KEY_PREFIX = "wcp.pickems.bracketDraft";
 
 export function bracketDraftKey(userId: string | undefined): string {
   return `${KEY_PREFIX}.${userId ?? "anonymous"}`;
@@ -9,10 +17,22 @@ export function bracketDraftKey(userId: string | undefined): string {
 export function readBracketDraft(userId: string | undefined): BracketDraft {
   if (typeof window === "undefined") return {};
   try {
+    window.localStorage.removeItem(`${LEGACY_KEY_PREFIX}.${userId ?? "anonymous"}`);
     const raw = window.localStorage.getItem(bracketDraftKey(userId));
     if (!raw) return {};
     const parsed: unknown = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? (parsed as BracketDraft) : {};
+    if (!parsed || typeof parsed !== "object") return {};
+    const { base, data } = parsed as { base?: unknown; data?: unknown };
+    if (typeof base !== "string" || !data || typeof data !== "object") return {};
+    // Built on a server state that has since changed (e.g. submitted from
+    // another device) — the draft is stale and the server wins.
+    const currentBase = getDraftBase("bracket");
+    if (currentBase === null) return {};
+    if (base !== currentBase) {
+      window.localStorage.removeItem(bracketDraftKey(userId));
+      return {};
+    }
+    return data as BracketDraft;
   } catch {
     return {};
   }
@@ -20,8 +40,10 @@ export function readBracketDraft(userId: string | undefined): BracketDraft {
 
 export function writeBracketDraft(userId: string | undefined, draft: BracketDraft): void {
   if (typeof window === "undefined") return;
+  const base = getDraftBase("bracket");
+  if (base === null) return; // no server state seen yet — nothing to stamp against
   try {
-    window.localStorage.setItem(bracketDraftKey(userId), JSON.stringify(draft));
+    window.localStorage.setItem(bracketDraftKey(userId), JSON.stringify({ base, data: draft }));
   } catch {
     // ignore — storage may be unavailable (private mode, quota, etc.)
   }

--- a/src/features/pickems/lib/draftBaseline.ts
+++ b/src/features/pickems/lib/draftBaseline.ts
@@ -1,0 +1,54 @@
+import type { Team } from "@/shared/types/wcp.types";
+
+import type { ResolvedGroupPick, UserPickem } from "../types/pickems.types";
+
+import { bracketSignature } from "./projectBracket";
+
+/** Stable identity of the group picks: per-group ranked order + lock flag. */
+export function groupsSignature(groups: ResolvedGroupPick[]): string {
+  return [...groups]
+    .sort((a, b) => a.group_code.localeCompare(b.group_code))
+    .map((group) => `${group.group_code}:${group.teams.map((team) => team.fifa_code).join("-")}:${group.locked ? 1 : 0}`)
+    .join(",");
+}
+
+/** Stable identity of the best-thirds selection. Order-insensitive — it's a set, not a ranking. */
+export function thirdsSignature(thirds: Team[]): string {
+  return thirds
+    .map((team) => team.fifa_code)
+    .sort()
+    .join(",");
+}
+
+type DraftBaseline = { groups: string; thirds: string; bracket: string };
+
+/**
+ * Last server-confirmed pickem state this session has seen, as one signature
+ * per draft slice. Persisted drafts are stamped with the slice signature they
+ * were built on (see the *DraftStorage modules); a draft whose stamp no longer
+ * matches was based on a server state that has since changed — typically a
+ * save from another device — so it's stale and the server wins.
+ *
+ * Synced from every server response (initial RSC payload, query refetches,
+ * mutation responses). Module-level on purpose: it must outlive component
+ * mounts, since on SPA re-visits the query cache already carries draft
+ * overlays and can't be used to re-derive server truth.
+ */
+let baseline: DraftBaseline | null = null;
+
+export function syncDraftBaseline(data: UserPickem): void {
+  baseline = {
+    groups: groupsSignature(data.group_picks),
+    thirds: thirdsSignature(data.best_thirds),
+    bracket: bracketSignature(data.bracket),
+  };
+}
+
+/** Seed the baseline only if no server state has been seen yet this session. */
+export function initDraftBaseline(data: UserPickem): void {
+  if (!baseline) syncDraftBaseline(data);
+}
+
+export function getDraftBase(slice: keyof DraftBaseline): string | null {
+  return baseline ? baseline[slice] : null;
+}

--- a/src/features/pickems/lib/groupsDraftStorage.ts
+++ b/src/features/pickems/lib/groupsDraftStorage.ts
@@ -1,14 +1,20 @@
 import type { GroupCode } from "@/shared/types/wcp.types";
 
+import { getDraftBase } from "./draftBaseline";
+
 /** Per-group draft entry: the ordered FIFA codes plus the user's lock state. */
 export type GroupDraftEntry = { order: string[]; locked: boolean };
 
 /** Pending step-1 state per group, e.g. `{ A: { order: ["CAN", "MEX", ...], locked: true }, ... }`. */
 export type GroupsDraft = Record<GroupCode, GroupDraftEntry>;
 
-// v2: entries changed from `string[]` (order only) to `{ order, locked }`. The bump
-// makes any old array-shaped draft fall out of scope instead of being mis-parsed.
-const KEY_PREFIX = "wcp.pickems.groupsDraft.v2";
+// v3: draft wrapped in a `{ base, data }` envelope, where `base` is the
+// signature of the server state the draft was built on (see `draftBaseline`).
+// The bump makes any un-stamped draft fall out of scope — those carry no
+// recency information, so a stale one could clobber picks submitted from
+// another device.
+const KEY_PREFIX = "wcp.pickems.groupsDraft.v3";
+const LEGACY_KEY_PREFIXES = ["wcp.pickems.groupsDraft.v2", "wcp.pickems.groupsDraft"];
 
 export function groupsDraftKey(userId: string | undefined): string {
   return `${KEY_PREFIX}.${userId ?? "anonymous"}`;
@@ -17,10 +23,22 @@ export function groupsDraftKey(userId: string | undefined): string {
 export function readGroupsDraft(userId: string | undefined): GroupsDraft | null {
   if (typeof window === "undefined") return null;
   try {
+    for (const prefix of LEGACY_KEY_PREFIXES) window.localStorage.removeItem(`${prefix}.${userId ?? "anonymous"}`);
     const raw = window.localStorage.getItem(groupsDraftKey(userId));
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? (parsed as GroupsDraft) : null;
+    if (!parsed || typeof parsed !== "object") return null;
+    const { base, data } = parsed as { base?: unknown; data?: unknown };
+    if (typeof base !== "string" || !data || typeof data !== "object") return null;
+    // Built on a server state that has since changed (e.g. saved from another
+    // device) — the draft is stale and the server wins.
+    const currentBase = getDraftBase("groups");
+    if (currentBase === null) return null;
+    if (base !== currentBase) {
+      window.localStorage.removeItem(groupsDraftKey(userId));
+      return null;
+    }
+    return data as GroupsDraft;
   } catch {
     return null;
   }
@@ -28,8 +46,10 @@ export function readGroupsDraft(userId: string | undefined): GroupsDraft | null 
 
 export function writeGroupsDraft(userId: string | undefined, draft: GroupsDraft): void {
   if (typeof window === "undefined") return;
+  const base = getDraftBase("groups");
+  if (base === null) return; // no server state seen yet — nothing to stamp against
   try {
-    window.localStorage.setItem(groupsDraftKey(userId), JSON.stringify(draft));
+    window.localStorage.setItem(groupsDraftKey(userId), JSON.stringify({ base, data: draft }));
   } catch {
     // ignore — storage may be unavailable (private mode, quota, etc.)
   }

--- a/src/features/pickems/lib/projectBracket.ts
+++ b/src/features/pickems/lib/projectBracket.ts
@@ -89,12 +89,15 @@ export function findChampion(bracket: BracketMatchSlot[]): Team | null {
 /**
  * Stable string identity of a bracket's picks (one `matchId:fifaCode` per slot,
  * empty when unpicked). Used to tell whether the locally-projected board differs
- * from what's already committed on the server — i.e. whether there's anything to
- * auto-save. Both inputs come from the same server array order, so a plain map is
- * order-stable; no sort needed.
+ * from what's already committed on the server (auto-save gate) and as the draft
+ * staleness baseline (see `draftBaseline`). The latter compares signatures across
+ * separate server responses, so sort by match_id rather than trusting array order.
  */
 export function bracketSignature(bracket: BracketMatchSlot[]): string {
-  return bracket.map((slot) => `${slot.match_id}:${slot.picked_team?.fifa_code ?? ""}`).join(",");
+  return [...bracket]
+    .sort((a, b) => a.match_id - b.match_id)
+    .map((slot) => `${slot.match_id}:${slot.picked_team?.fifa_code ?? ""}`)
+    .join(",");
 }
 
 /**


### PR DESCRIPTION
## What changed

- Stamp each localStorage draft (groups, best thirds, bracket) with a signature of the server state it was built on; on read, a mismatched stamp means another device saved since, so the draft is discarded and the server wins
- New `draftBaseline` module tracks the last server-confirmed state, seeded from the RSC payload and re-synced on every fetch/mutation response
- Stops the bracket auto-save from silently overwriting picks submitted on another device
- Version-bumped draft storage keys so existing un-stamped drafts in the wild fall out of scope; legacy keys cleaned up on read

## How to test

- [ ] Edit groups on device A without saving, submit full pickems from device B, reload device A — server picks show, old draft is gone, no auto-save fires
- [ ] On one device: reorder groups, reload — pending edits are restored (same-device drafts still work)
- [ ] Complete the bracket, wait 1s for auto-save, reload — picks persist with no stray draft applied
- [ ] Check localStorage: old `wcp.pickems.*Draft` keys are removed, new versioned keys carry `{ base, data }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)