### PR TITLE
fix(pickems): redirect to correct step when server state is behind URL

### DIFF
--- a/src/features/pickems/components/PickemsView.tsx
+++ b/src/features/pickems/components/PickemsView.tsx
@@ -14,7 +14,7 @@ import { useSaveGroups } from "../hooks/useSaveGroups";
 import { useStep } from "../hooks/useStep";
 import { readBestThirdsDraft } from "../lib/bestThirdsDraftStorage";
 import { readGroupsDraft } from "../lib/groupsDraftStorage";
-import { stepIndex } from "../lib/pickemStep";
+import { highestValidStep, stepIndex } from "../lib/pickemStep";
 import { projectBracket, pruneBracketDraft } from "../lib/projectBracket";
 import type { BracketDraft, PickemProgress, PickemStep, UserPickem } from "../types/pickems.types";
 
@@ -43,6 +43,36 @@ export function PickemsView({ initialData, userId }: Props) {
   const bestThirdsSave = useSaveBestThirds(userId);
   const [navigating, setNavigating] = useState(false);
 
+  // Cross-device step guard: if the URL carries a step ahead of what the server
+  // committed (e.g. `?step=bracket` left over from a previous session while
+  // another device reset groups/thirds), we must show the correct step without
+  // a flash. `effectiveStep` starts as the clamped value from `useState` so the
+  // render is immediately correct; the URL is fixed asynchronously once the
+  // mount effect runs.
+  const maxStepOnLoad: PickemStep = !initialData.is_locked ? highestValidStep(initialData) : "bracket";
+  const [effectiveStep, setEffectiveStep] = useState<PickemStep>(() => (stepIndex(step) > stepIndex(maxStepOnLoad) ? maxStepOnLoad : step));
+  // Used ONLY inside effects — never during render (would violate React Compiler rules).
+  const mountCorrectionDone = useRef(false);
+
+  // MUST be declared before the mount-correction effect so it fires first on mount.
+  // Effects run in declaration order: on mount `mountCorrectionDone.current` is still
+  // false here, so we skip; subsequent URL changes (from the correction or user nav)
+  // arrive after the flag is set and drive effectiveStep going forward.
+  useEffect(() => {
+    if (!mountCorrectionDone.current) return;
+    setEffectiveStep(step);
+  }, [step]);
+
+  // Mount-only: open the step sync, then correct the URL + toast if needed.
+  useEffect(() => {
+    mountCorrectionDone.current = true;
+    if (stepIndex(step) > stepIndex(maxStepOnLoad)) {
+      rawSetStep(maxStepOnLoad);
+      toast.info(tToasts("crossDeviceStepReset"));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Each step is its own screen — land at the top when moving between them
   // (e.g. Continue from groups → best thirds → bracket) so the new step's header
   // is in view rather than wherever the previous step was scrolled. Skips the
@@ -54,7 +84,7 @@ export function PickemsView({ initialData, userId }: Props) {
       return;
     }
     window.scrollTo({ top: 0, behavior: "smooth" });
-  }, [step]);
+  }, [effectiveStep]);
 
   // When the pickem is locked the server is read-only; localStorage drafts can
   // never sync, so ignore them and project against the server-saved state only
@@ -163,10 +193,10 @@ export function PickemsView({ initialData, userId }: Props) {
           step header + stepper so it stays prominent regardless of step. */}
       <AwardsCrossSell isLocked={data.is_locked} />
 
-      {step === "groups" && (
+      {effectiveStep === "groups" && (
         <StepGroups
           data={data}
-          step={step}
+          step={effectiveStep}
           onStep={setStep}
           progress={progress}
           canNavigateTo={canNavigateTo}
@@ -186,10 +216,10 @@ export function PickemsView({ initialData, userId }: Props) {
           isSaving={groupsSave.isSaving || navigating}
         />
       )}
-      {step === "thirds" && (
+      {effectiveStep === "thirds" && (
         <StepBestThirds
           data={data}
-          step={step}
+          step={effectiveStep}
           onStep={setStep}
           progress={progress}
           canNavigateTo={canNavigateTo}
@@ -207,7 +237,7 @@ export function PickemsView({ initialData, userId }: Props) {
           isSaving={bestThirdsSave.isSaving || navigating}
         />
       )}
-      {step === "bracket" && <StepBracket data={data} step={step} onStep={setStep} progress={progress} canNavigateTo={canNavigateTo} userId={userId} />}
+      {effectiveStep === "bracket" && <StepBracket data={data} step={effectiveStep} onStep={setStep} progress={progress} canNavigateTo={canNavigateTo} userId={userId} />}
     </div>
   );
 }

--- a/src/features/pickems/lib/pickemStep.ts
+++ b/src/features/pickems/lib/pickemStep.ts
@@ -1,4 +1,4 @@
-import type { PickemStep } from "../types/pickems.types";
+import type { PickemStep, UserPickem } from "../types/pickems.types";
 
 export const PICKEM_STEPS: readonly PickemStep[] = ["groups", "thirds", "bracket"];
 
@@ -15,4 +15,18 @@ export function stepIndex(step: PickemStep): number {
 export function prevStep(step: PickemStep): PickemStep | null {
   const i = stepIndex(step);
   return i > 0 ? PICKEM_STEPS[i - 1] : null;
+}
+
+/**
+ * Returns the furthest step reachable given the server-committed pickem state
+ * (no local draft overlay). Used on load to detect when the URL step is ahead
+ * of what the server data actually supports — e.g. the user completed and
+ * submitted on mobile while this device still has `?step=bracket` in the URL.
+ */
+export function highestValidStep(data: UserPickem): PickemStep {
+  if (data.is_locked) return "bracket";
+  const groupsDone = data.group_picks.length > 0 && data.group_picks.every((g) => g.locked);
+  if (!groupsDone) return "groups";
+  if (data.best_thirds.length < 8) return "thirds";
+  return "bracket";
 }

--- a/src/i18n/messages/pickems/en.json
+++ b/src/i18n/messages/pickems/en.json
@@ -87,6 +87,7 @@
     "lockAllGroupsFirst": "Lock all 12 groups before continuing",
     "selectAllThirdsFirst": "Pick all 8 best thirds before continuing",
     "finishRoundFirst": "Finish this round before continuing",
-    "pickAllBracketFirst": "Pick all 32 winners before submitting"
+    "pickAllBracketFirst": "Pick all 32 winners before submitting",
+    "crossDeviceStepReset": "Your picks were updated from another device"
   }
 }

--- a/src/i18n/messages/pickems/es.json
+++ b/src/i18n/messages/pickems/es.json
@@ -87,6 +87,7 @@
     "lockAllGroupsFirst": "Confirma los 12 grupos antes de continuar",
     "selectAllThirdsFirst": "Elige los 8 mejores terceros antes de continuar",
     "finishRoundFirst": "Termina esta ronda antes de continuar",
-    "pickAllBracketFirst": "Elige los 32 ganadores antes de guardar tus picks"
+    "pickAllBracketFirst": "Elige los 32 ganadores antes de guardar tus picks",
+    "crossDeviceStepReset": "Tus picks fueron actualizados desde otro dispositivo"
   }
 }


### PR DESCRIPTION
## What changed

- Compute the highest step reachable from the server-committed payload on load; clamp `effectiveStep` to it via `useState` initializer so the correct step renders immediately (no flash)
- Mount effect corrects the URL asynchronously and shows a toast when a cross-device mismatch is detected
- Scroll-to-top effect keyed on `effectiveStep` so it doesn't fire on the automatic URL correction, only on user-initiated navigation
- Added `highestValidStep(data)` helper to `pickemStep.ts`

## How to test

- [ ] On device A, reach step 3 (bracket) and leave the tab open (URL has `?step=bracket`)
- [ ] On device B, change group order or best thirds — this resets bracket on the server
- [ ] Reload device A — should land on the correct step (groups or best thirds) with a toast "Your picks were updated from another device", not an empty bracket
- [ ] Normal forward navigation after the redirect still works (can progress through steps)
- [ ] No cross-device change: reload with `?step=bracket` when picks are intact — no redirect, no toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)