### PR TITLE
chore: release v1.2.3

### DIFF
--- a/src/app/[locale]/bracket/page.tsx
+++ b/src/app/[locale]/bracket/page.tsx
@@ -1,11 +1,42 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { PlaceholderPage } from "@/shared/components/PlaceholderPage";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
+import { buildPageMetadata } from "@/shared/seo/metadata";
 
-export const metadata: Metadata = { title: "Bracket | WCP" };
+type Props = { params: Promise<{ locale: string }> };
 
-export default async function BracketPage() {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  return buildPageMetadata({ locale, namespace: "seo.bracket", path: "/bracket" });
+}
+
+export default async function BracketPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
   const t = await getTranslations("pages");
-  return <PlaceholderPage eyebrow={t("comingSoonBadge")} title={t("bracket.title")} body={t("bracket.body")} />;
+
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const bracketLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildBreadcrumbJsonLd(
+        [
+          { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+          { name: "Bracket", url: `${SITE_URL}${prefix}/bracket` },
+        ],
+        locale
+      ),
+    ],
+  };
+
+  return (
+    <>
+      <JsonLd data={bracketLd} />
+      <PlaceholderPage eyebrow={t("comingSoonBadge")} title={t("bracket.title")} body={t("bracket.body")} />
+    </>
+  );
 }

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import { Link } from "@/i18n/navigation";
+import { SITE_URL } from "@/lib/site";
 import { JsonLd } from "@/shared/components/JsonLd";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/shared/components/ui/accordion";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 type Props = { params: Promise<{ locale: string }> };
@@ -24,22 +26,31 @@ export default async function FaqPage({ params }: Props) {
   const t = await getTranslations("pages.faq");
 
   const stripTags = { rulesLink: (c: string) => c, boardsLink: (c: string) => c, howItWorksLink: (c: string) => c };
-  const faqJsonLd = {
+  const faqItems = FAQ_KEYS.map((key) => ({
+    "@type": "Question",
+    name: t(`items.${key}.question`),
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: t.markup(`items.${key}.answer`, stripTags),
+    },
+  }));
+
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const breadcrumb = buildBreadcrumbJsonLd(
+    [
+      { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+      { name: "FAQ", url: `${SITE_URL}${prefix}/faq` },
+    ],
+    locale
+  );
+  const combinedLd = {
     "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: FAQ_KEYS.map((key) => ({
-      "@type": "Question",
-      name: t(`items.${key}.question`),
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: t.markup(`items.${key}.answer`, stripTags),
-      },
-    })),
+    "@graph": [{ "@type": "FAQPage", mainEntity: faqItems }, breadcrumb],
   };
 
   return (
     <section className="container py-6 lg:py-8">
-      <JsonLd data={faqJsonLd} />
+      <JsonLd data={combinedLd} />
       <div className="flex flex-col gap-10">
         <header className="flex flex-col gap-4 border-b border-border pb-10">
           <span className={eyebrow}>{t("eyebrow")}</span>

--- a/src/app/[locale]/how-it-works/page.tsx
+++ b/src/app/[locale]/how-it-works/page.tsx
@@ -2,7 +2,10 @@ import { Award, BarChart3, Medal, Target, Trophy, UserPlus, Users, type LucideIc
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { Card } from "@/shared/components/ui/card";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 type Props = { params: Promise<{ locale: string }> };
@@ -41,8 +44,23 @@ export default async function HowItWorksPage({ params }: Props) {
   setRequestLocale(locale);
   const t = await getTranslations("pages.howItWorks");
 
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const howItWorksLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildBreadcrumbJsonLd(
+        [
+          { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+          { name: "How to Play", url: `${SITE_URL}${prefix}/how-it-works` },
+        ],
+        locale
+      ),
+    ],
+  };
+
   return (
     <section className="container py-6 lg:py-8">
+      <JsonLd data={howItWorksLd} />
       <div className="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:items-start lg:gap-12 xl:gap-20">
         <div className="flex flex-col gap-6 lg:sticky lg:top-24 lg:max-w-sm lg:self-start">
           <Hero eyebrow={t("eyebrow")} title={t("title")} intro={t("intro")} />

--- a/src/app/[locale]/rules/page.tsx
+++ b/src/app/[locale]/rules/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { Card } from "@/shared/components/ui/card";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 type Props = { params: Promise<{ locale: string }> };
@@ -53,8 +56,23 @@ export default async function RulesPage({ params }: Props) {
   setRequestLocale(locale);
   const t = await getTranslations("pages.rules");
 
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const rulesLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildBreadcrumbJsonLd(
+        [
+          { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+          { name: "Rules", url: `${SITE_URL}${prefix}/rules` },
+        ],
+        locale
+      ),
+    ],
+  };
+
   return (
     <section className="container py-6 lg:py-8">
+      <JsonLd data={rulesLd} />
       <div className="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:items-start lg:gap-12 xl:gap-20">
         <div className="flex flex-col gap-6 lg:sticky lg:top-24 lg:max-w-sm lg:self-start">
           <Hero eyebrow={t("eyebrow")} title={t("title")} intro={t("intro")} />

--- a/src/app/[locale]/schedule/page.tsx
+++ b/src/app/[locale]/schedule/page.tsx
@@ -4,10 +4,14 @@ import { getTranslations } from "next-intl/server";
 
 import { MATCHES_CACHE_TAG } from "@/features/schedule/api/matches";
 import { ScheduleView } from "@/features/schedule/components/ScheduleView";
+import { buildScheduleJsonLd } from "@/features/schedule/lib/buildScheduleJsonLd";
 import { findAnchorMatchId } from "@/features/schedule/lib/findAnchorMatch";
 import type { Match } from "@/features/schedule/types/schedule.types";
 import { getCurrentUser } from "@/lib/auth";
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { serverApi } from "@/shared/lib/api/server";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 type Props = { params: Promise<{ locale: string }>; searchParams: Promise<{ match?: string }> };
@@ -17,9 +21,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildPageMetadata({ locale, namespace: "seo.schedule", path: "/schedule" });
 }
 
-export default async function SchedulePage({ searchParams }: Props) {
+export default async function SchedulePage({ params, searchParams }: Props) {
   const t = await getTranslations("schedule");
-  const [user, { match }] = await Promise.all([getCurrentUser(), searchParams]);
+  const [{ locale }, user, { match }] = await Promise.all([params, getCurrentUser(), searchParams]);
   const deepLinkMatchId = match && Number.isFinite(Number(match)) ? Number(match) : null;
 
   const res = await serverApi.get<Match[]>("/api/matches", {
@@ -34,9 +38,21 @@ export default async function SchedulePage({ searchParams }: Props) {
     throw new Error(res.error?.message ?? "Failed to load matches");
   }
 
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const eventsData = buildScheduleJsonLd(res.data, locale);
+  const breadcrumb = buildBreadcrumbJsonLd(
+    [
+      { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+      { name: "Schedule", url: `${SITE_URL}${prefix}/schedule` },
+    ],
+    locale
+  );
+  const scheduleLd = { "@context": "https://schema.org", "@graph": [...eventsData["@graph"], breadcrumb] };
+
   return (
     <>
       <h1 className="sr-only">{t("title")}</h1>
+      <JsonLd data={scheduleLd} />
       {/* ScheduleView reads filters from the URL via useSearchParams,
           which Next.js requires under a Suspense boundary. */}
       <Suspense>

--- a/src/app/[locale]/standings/page.tsx
+++ b/src/app/[locale]/standings/page.tsx
@@ -7,7 +7,10 @@ import { STANDINGS_CACHE_TAG } from "@/features/standings/api/standings";
 import { StandingsView } from "@/features/standings/components/StandingsView";
 import type { StandingRow } from "@/features/standings/types/standings.types";
 import { getCurrentUser } from "@/lib/auth";
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/shared/components/JsonLd";
 import { serverApi } from "@/shared/lib/api/server";
+import { buildBreadcrumbJsonLd } from "@/shared/seo/breadcrumbs";
 import { buildPageMetadata } from "@/shared/seo/metadata";
 
 import StandingsLoading from "./loading";
@@ -17,8 +20,8 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return buildPageMetadata({ locale, namespace: "seo.standings", path: "/standings" });
 }
 
-export default async function StandingsPage() {
-  const user = await getCurrentUser();
+export default async function StandingsPage({ params }: { params: Promise<{ locale: string }> }) {
+  const [{ locale }, user] = await Promise.all([params, getCurrentUser()]);
 
   // Public endpoint — guests welcome. A failure here is fatal: without the
   // table there is no page, so let the error boundary take over.
@@ -44,13 +47,26 @@ export default async function StandingsPage() {
     else pickemFailed = true;
   }
 
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const breadcrumbLd = buildBreadcrumbJsonLd(
+    [
+      { name: "Pick'ems", url: `${SITE_URL}${prefix}` },
+      { name: "Standings", url: `${SITE_URL}${prefix}/standings` },
+    ],
+    locale
+  );
+  const standingsLd = { "@context": "https://schema.org", "@graph": [breadcrumbLd] };
+
   // StandingsView reads the compare toggle from the URL via useSearchParams,
   // which Next.js requires under a Suspense boundary. The route-level
   // `loading.tsx` covers the *initial* paint; this fallback covers any later
   // client transition that suspends — without it the page would blank out.
   return (
-    <Suspense fallback={<StandingsLoading />}>
-      <StandingsView initialStandings={standingsRes.data} initialPickem={pickem} pickemFailed={pickemFailed} isAuthed={Boolean(user)} />
-    </Suspense>
+    <>
+      <JsonLd data={standingsLd} />
+      <Suspense fallback={<StandingsLoading />}>
+        <StandingsView initialStandings={standingsRes.data} initialPickem={pickem} pickemFailed={pickemFailed} isAuthed={Boolean(user)} />
+      </Suspense>
+    </>
   );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,17 +2,18 @@ import type { MetadataRoute } from "next";
 
 import { SITE_URL } from "@/lib/site";
 
-// Public, crawlable routes only — excludes auth-gated pages and placeholders.
-const PUBLIC_PATHS = ["", "/schedule", "/standings", "/how-it-works", "/rules", "/privacy", "/terms"];
+const PUBLIC_PATHS = ["", "/schedule", "/standings", "/bracket", "/faq", "/how-it-works", "/rules", "/privacy", "/terms"];
+
+function sitemapEntry(path: string): MetadataRoute.Sitemap[number] {
+  const enUrl = `${SITE_URL}${path || "/"}`;
+  const esUrl = `${SITE_URL}/es${path}`;
+  return {
+    url: enUrl,
+    lastModified: new Date("2026-06-09"),
+    alternates: { languages: { en: enUrl, es: esUrl, "x-default": enUrl } },
+  };
+}
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return PUBLIC_PATHS.map((path) => ({
-    url: `${SITE_URL}${path || "/"}`,
-    alternates: {
-      languages: {
-        en: `${SITE_URL}${path || "/"}`,
-        es: `${SITE_URL}/es${path}`,
-      },
-    },
-  }));
+  return PUBLIC_PATHS.map(sitemapEntry);
 }

--- a/src/features/pickems/api/pickems.ts
+++ b/src/features/pickems/api/pickems.ts
@@ -1,6 +1,7 @@
 import { api } from "@/shared/lib/api/client";
 import { ApiClientError } from "@/shared/lib/api/errors";
 
+import { syncDraftBaseline } from "../lib/draftBaseline";
 import type { SaveBestThirdsPayload, SaveBracketPicksPayload, SaveGroupPicksPayload, UserPickem } from "../types/pickems.types";
 
 export const PICKEMS_QUERY_KEY = ["pickems"] as const;
@@ -12,6 +13,8 @@ export async function fetchPickems(): Promise<UserPickem> {
     throw new Error(res.error?.message ?? "Failed to load pickems");
   }
 
+  // Every fetch result is server truth — keep the draft-staleness baseline current.
+  syncDraftBaseline(res.data);
   return res.data;
 }
 

--- a/src/features/pickems/components/PickemsView.tsx
+++ b/src/features/pickems/components/PickemsView.tsx
@@ -15,7 +15,7 @@ import { useSaveGroups } from "../hooks/useSaveGroups";
 import { useStep } from "../hooks/useStep";
 import { readBestThirdsDraft } from "../lib/bestThirdsDraftStorage";
 import { readGroupsDraft } from "../lib/groupsDraftStorage";
-import { stepIndex } from "../lib/pickemStep";
+import { highestValidStep, stepIndex } from "../lib/pickemStep";
 import { projectBracket, pruneBracketDraft } from "../lib/projectBracket";
 import type { BracketDraft, PickemProgress, PickemStep, UserPickem } from "../types/pickems.types";
 
@@ -47,6 +47,36 @@ export function PickemsView({ initialData, userId }: Props) {
   const bestThirdsSave = useSaveBestThirds(userId);
   const [navigating, setNavigating] = useState(false);
 
+  // Cross-device step guard: if the URL carries a step ahead of what the server
+  // committed (e.g. `?step=bracket` left over from a previous session while
+  // another device reset groups/thirds), we must show the correct step without
+  // a flash. `effectiveStep` starts as the clamped value from `useState` so the
+  // render is immediately correct; the URL is fixed asynchronously once the
+  // mount effect runs.
+  const maxStepOnLoad: PickemStep = !initialData.is_locked ? highestValidStep(initialData) : "bracket";
+  const [effectiveStep, setEffectiveStep] = useState<PickemStep>(() => (stepIndex(step) > stepIndex(maxStepOnLoad) ? maxStepOnLoad : step));
+  // Used ONLY inside effects — never during render (would violate React Compiler rules).
+  const mountCorrectionDone = useRef(false);
+
+  // MUST be declared before the mount-correction effect so it fires first on mount.
+  // Effects run in declaration order: on mount `mountCorrectionDone.current` is still
+  // false here, so we skip; subsequent URL changes (from the correction or user nav)
+  // arrive after the flag is set and drive effectiveStep going forward.
+  useEffect(() => {
+    if (!mountCorrectionDone.current) return;
+    setEffectiveStep(step);
+  }, [step]);
+
+  // Mount-only: open the step sync, then correct the URL + toast if needed.
+  useEffect(() => {
+    mountCorrectionDone.current = true;
+    if (stepIndex(step) > stepIndex(maxStepOnLoad)) {
+      rawSetStep(maxStepOnLoad);
+      toast.info(tToasts("crossDeviceStepReset"));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Each step is its own screen — land at the top when moving between them
   // (e.g. Continue from groups → best thirds → bracket) so the new step's header
   // is in view rather than wherever the previous step was scrolled. Skips the
@@ -58,7 +88,7 @@ export function PickemsView({ initialData, userId }: Props) {
       return;
     }
     window.scrollTo({ top: 0, behavior: "smooth" });
-  }, [step]);
+  }, [effectiveStep]);
 
   // When the pickem is locked the server is read-only; localStorage drafts can
   // never sync, so ignore them and project against the server-saved state only
@@ -167,10 +197,10 @@ export function PickemsView({ initialData, userId }: Props) {
           step header + stepper so it stays prominent regardless of step. */}
       <AwardsCrossSell isLocked={data.is_locked} />
 
-      {step === "groups" && (
+      {effectiveStep === "groups" && (
         <StepGroups
           data={data}
-          step={step}
+          step={effectiveStep}
           onStep={setStep}
           progress={progress}
           canNavigateTo={canNavigateTo}
@@ -190,10 +220,10 @@ export function PickemsView({ initialData, userId }: Props) {
           isSaving={groupsSave.isSaving || navigating}
         />
       )}
-      {step === "thirds" && (
+      {effectiveStep === "thirds" && (
         <StepBestThirds
           data={data}
-          step={step}
+          step={effectiveStep}
           onStep={setStep}
           progress={progress}
           canNavigateTo={canNavigateTo}
@@ -211,7 +241,7 @@ export function PickemsView({ initialData, userId }: Props) {
           isSaving={bestThirdsSave.isSaving || navigating}
         />
       )}
-      {step === "bracket" && <StepBracket data={data} step={step} onStep={setStep} progress={progress} canNavigateTo={canNavigateTo} userId={userId} />}
+      {effectiveStep === "bracket" && <StepBracket data={data} step={effectiveStep} onStep={setStep} progress={progress} canNavigateTo={canNavigateTo} userId={userId} />}
     </div>
   );
 }

--- a/src/features/pickems/components/PickemsView.tsx
+++ b/src/features/pickems/components/PickemsView.tsx
@@ -8,6 +8,7 @@ import { AwardsCrossSell } from "@/features/awards/components/AwardsCrossSell";
 import { useHydrated } from "@/shared/hooks/useHydrated";
 
 import { useBracketDraft } from "../hooks/useBracketDraft";
+import { useDraftBaseline } from "../hooks/useDraftBaseline";
 import { usePickems } from "../hooks/usePickems";
 import { useSaveBestThirds } from "../hooks/useSaveBestThirds";
 import { useSaveGroups } from "../hooks/useSaveGroups";
@@ -36,6 +37,9 @@ const EMPTY_BRACKET_DRAFT: BracketDraft = {};
 export function PickemsView({ initialData, userId }: Props) {
   const hydrated = useHydrated();
   const tToasts = useTranslations("pickems.toasts");
+  // Must come before the draft hooks below — their localStorage reads validate
+  // drafts against this baseline, and layout effects run in declaration order.
+  useDraftBaseline(initialData);
   const { data = initialData } = usePickems(initialData);
   const [step, rawSetStep] = useStep();
   const { draft: bracketDraft, replaceDraft: replaceBracketDraft, isHydrated: bracketDraftHydrated } = useBracketDraft(userId);

--- a/src/features/pickems/hooks/useDraftBaseline.ts
+++ b/src/features/pickems/hooks/useDraftBaseline.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useIsomorphicLayoutEffect } from "@/shared/hooks/useIsomorphicLayoutEffect";
+
+import { PICKEMS_QUERY_KEY } from "../api/pickems";
+import { initDraftBaseline } from "../lib/draftBaseline";
+import type { UserPickem } from "../types/pickems.types";
+
+/**
+ * Seeds the draft-staleness baseline from the first server snapshot of the
+ * session. Must be the first draft hook PickemsView calls: the storage reads
+ * in useBracketDraft / useSaveGroups / useSaveBestThirds validate their drafts
+ * against this baseline, and layout effects run in declaration order. On the
+ * first mount the query cache is still the untouched server payload; later
+ * mounts are no-ops (the baseline then tracks fetch/mutation responses).
+ */
+export function useDraftBaseline(initialData: UserPickem): void {
+  const qc = useQueryClient();
+
+  useIsomorphicLayoutEffect(() => {
+    initDraftBaseline(qc.getQueryData<UserPickem>(PICKEMS_QUERY_KEY) ?? initialData);
+  }, [qc, initialData]);
+}

--- a/src/features/pickems/hooks/usePickemMutation.ts
+++ b/src/features/pickems/hooks/usePickemMutation.ts
@@ -8,6 +8,7 @@ import { ApiClientError } from "@/shared/lib/api/errors";
 
 import { PICKEMS_QUERY_KEY } from "../api/pickems";
 import { countClearedPicks } from "../lib/diffInvalidation";
+import { syncDraftBaseline } from "../lib/draftBaseline";
 import type { UserPickem } from "../types/pickems.types";
 
 type Options<TInput> = {
@@ -54,6 +55,10 @@ export function usePickemMutation<TInput>({
       toast.error(t(errorMessageKey));
     },
     onSuccess: (response, _input, ctx) => {
+      // The response is the new server truth — drafts written from here on are
+      // stamped against it, and older stamps become stale (see draftBaseline).
+      syncDraftBaseline(response);
+
       const current = qc.getQueryData<UserPickem>(PICKEMS_QUERY_KEY);
       if (current) {
         const merged = mergeServerResponse ? mergeServerResponse(current, response) : response;

--- a/src/features/pickems/lib/bestThirdsDraftStorage.ts
+++ b/src/features/pickems/lib/bestThirdsDraftStorage.ts
@@ -1,7 +1,15 @@
+import { getDraftBase } from "./draftBaseline";
+
 /** Ordered FIFA codes the user has marked as their best 3rd-place picks. */
 export type BestThirdsDraft = string[];
 
-const KEY_PREFIX = "wcp.pickems.bestThirdsDraft";
+// v2: draft wrapped in a `{ base, data }` envelope, where `base` is the
+// signature of the server state the draft was built on (see `draftBaseline`).
+// The bump makes any un-stamped draft fall out of scope — those carry no
+// recency information, so a stale one could clobber picks submitted from
+// another device.
+const KEY_PREFIX = "wcp.pickems.bestThirdsDraft.v2";
+const LEGACY_KEY_PREFIX = "wcp.pickems.bestThirdsDraft";
 
 export function bestThirdsDraftKey(userId: string | undefined): string {
   return `${KEY_PREFIX}.${userId ?? "anonymous"}`;
@@ -10,10 +18,22 @@ export function bestThirdsDraftKey(userId: string | undefined): string {
 export function readBestThirdsDraft(userId: string | undefined): BestThirdsDraft | null {
   if (typeof window === "undefined") return null;
   try {
+    window.localStorage.removeItem(`${LEGACY_KEY_PREFIX}.${userId ?? "anonymous"}`);
     const raw = window.localStorage.getItem(bestThirdsDraftKey(userId));
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed) && parsed.every((s) => typeof s === "string") ? (parsed as BestThirdsDraft) : null;
+    if (!parsed || typeof parsed !== "object") return null;
+    const { base, data } = parsed as { base?: unknown; data?: unknown };
+    if (typeof base !== "string" || !Array.isArray(data) || !data.every((s) => typeof s === "string")) return null;
+    // Built on a server state that has since changed (e.g. saved from another
+    // device) — the draft is stale and the server wins.
+    const currentBase = getDraftBase("thirds");
+    if (currentBase === null) return null;
+    if (base !== currentBase) {
+      window.localStorage.removeItem(bestThirdsDraftKey(userId));
+      return null;
+    }
+    return data as BestThirdsDraft;
   } catch {
     return null;
   }
@@ -21,8 +41,10 @@ export function readBestThirdsDraft(userId: string | undefined): BestThirdsDraft
 
 export function writeBestThirdsDraft(userId: string | undefined, draft: BestThirdsDraft): void {
   if (typeof window === "undefined") return;
+  const base = getDraftBase("thirds");
+  if (base === null) return; // no server state seen yet — nothing to stamp against
   try {
-    window.localStorage.setItem(bestThirdsDraftKey(userId), JSON.stringify(draft));
+    window.localStorage.setItem(bestThirdsDraftKey(userId), JSON.stringify({ base, data: draft }));
   } catch {
     // ignore — storage may be unavailable (private mode, quota, etc.)
   }

--- a/src/features/pickems/lib/bracketDraftStorage.ts
+++ b/src/features/pickems/lib/bracketDraftStorage.ts
@@ -1,6 +1,14 @@
 import type { BracketDraft } from "../types/pickems.types";
 
-const KEY_PREFIX = "wcp.pickems.bracketDraft";
+import { getDraftBase } from "./draftBaseline";
+
+// v2: draft wrapped in a `{ base, data }` envelope, where `base` is the
+// signature of the server state the draft was built on (see `draftBaseline`).
+// The bump makes any un-stamped draft fall out of scope — those carry no
+// recency information, so a stale one could clobber picks submitted from
+// another device.
+const KEY_PREFIX = "wcp.pickems.bracketDraft.v2";
+const LEGACY_KEY_PREFIX = "wcp.pickems.bracketDraft";
 
 export function bracketDraftKey(userId: string | undefined): string {
   return `${KEY_PREFIX}.${userId ?? "anonymous"}`;
@@ -9,10 +17,22 @@ export function bracketDraftKey(userId: string | undefined): string {
 export function readBracketDraft(userId: string | undefined): BracketDraft {
   if (typeof window === "undefined") return {};
   try {
+    window.localStorage.removeItem(`${LEGACY_KEY_PREFIX}.${userId ?? "anonymous"}`);
     const raw = window.localStorage.getItem(bracketDraftKey(userId));
     if (!raw) return {};
     const parsed: unknown = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? (parsed as BracketDraft) : {};
+    if (!parsed || typeof parsed !== "object") return {};
+    const { base, data } = parsed as { base?: unknown; data?: unknown };
+    if (typeof base !== "string" || !data || typeof data !== "object") return {};
+    // Built on a server state that has since changed (e.g. submitted from
+    // another device) — the draft is stale and the server wins.
+    const currentBase = getDraftBase("bracket");
+    if (currentBase === null) return {};
+    if (base !== currentBase) {
+      window.localStorage.removeItem(bracketDraftKey(userId));
+      return {};
+    }
+    return data as BracketDraft;
   } catch {
     return {};
   }
@@ -20,8 +40,10 @@ export function readBracketDraft(userId: string | undefined): BracketDraft {
 
 export function writeBracketDraft(userId: string | undefined, draft: BracketDraft): void {
   if (typeof window === "undefined") return;
+  const base = getDraftBase("bracket");
+  if (base === null) return; // no server state seen yet — nothing to stamp against
   try {
-    window.localStorage.setItem(bracketDraftKey(userId), JSON.stringify(draft));
+    window.localStorage.setItem(bracketDraftKey(userId), JSON.stringify({ base, data: draft }));
   } catch {
     // ignore — storage may be unavailable (private mode, quota, etc.)
   }

--- a/src/features/pickems/lib/draftBaseline.ts
+++ b/src/features/pickems/lib/draftBaseline.ts
@@ -1,0 +1,54 @@
+import type { Team } from "@/shared/types/wcp.types";
+
+import type { ResolvedGroupPick, UserPickem } from "../types/pickems.types";
+
+import { bracketSignature } from "./projectBracket";
+
+/** Stable identity of the group picks: per-group ranked order + lock flag. */
+export function groupsSignature(groups: ResolvedGroupPick[]): string {
+  return [...groups]
+    .sort((a, b) => a.group_code.localeCompare(b.group_code))
+    .map((group) => `${group.group_code}:${group.teams.map((team) => team.fifa_code).join("-")}:${group.locked ? 1 : 0}`)
+    .join(",");
+}
+
+/** Stable identity of the best-thirds selection. Order-insensitive — it's a set, not a ranking. */
+export function thirdsSignature(thirds: Team[]): string {
+  return thirds
+    .map((team) => team.fifa_code)
+    .sort()
+    .join(",");
+}
+
+type DraftBaseline = { groups: string; thirds: string; bracket: string };
+
+/**
+ * Last server-confirmed pickem state this session has seen, as one signature
+ * per draft slice. Persisted drafts are stamped with the slice signature they
+ * were built on (see the *DraftStorage modules); a draft whose stamp no longer
+ * matches was based on a server state that has since changed — typically a
+ * save from another device — so it's stale and the server wins.
+ *
+ * Synced from every server response (initial RSC payload, query refetches,
+ * mutation responses). Module-level on purpose: it must outlive component
+ * mounts, since on SPA re-visits the query cache already carries draft
+ * overlays and can't be used to re-derive server truth.
+ */
+let baseline: DraftBaseline | null = null;
+
+export function syncDraftBaseline(data: UserPickem): void {
+  baseline = {
+    groups: groupsSignature(data.group_picks),
+    thirds: thirdsSignature(data.best_thirds),
+    bracket: bracketSignature(data.bracket),
+  };
+}
+
+/** Seed the baseline only if no server state has been seen yet this session. */
+export function initDraftBaseline(data: UserPickem): void {
+  if (!baseline) syncDraftBaseline(data);
+}
+
+export function getDraftBase(slice: keyof DraftBaseline): string | null {
+  return baseline ? baseline[slice] : null;
+}

--- a/src/features/pickems/lib/groupsDraftStorage.ts
+++ b/src/features/pickems/lib/groupsDraftStorage.ts
@@ -1,14 +1,20 @@
 import type { GroupCode } from "@/shared/types/wcp.types";
 
+import { getDraftBase } from "./draftBaseline";
+
 /** Per-group draft entry: the ordered FIFA codes plus the user's lock state. */
 export type GroupDraftEntry = { order: string[]; locked: boolean };
 
 /** Pending step-1 state per group, e.g. `{ A: { order: ["CAN", "MEX", ...], locked: true }, ... }`. */
 export type GroupsDraft = Record<GroupCode, GroupDraftEntry>;
 
-// v2: entries changed from `string[]` (order only) to `{ order, locked }`. The bump
-// makes any old array-shaped draft fall out of scope instead of being mis-parsed.
-const KEY_PREFIX = "wcp.pickems.groupsDraft.v2";
+// v3: draft wrapped in a `{ base, data }` envelope, where `base` is the
+// signature of the server state the draft was built on (see `draftBaseline`).
+// The bump makes any un-stamped draft fall out of scope — those carry no
+// recency information, so a stale one could clobber picks submitted from
+// another device.
+const KEY_PREFIX = "wcp.pickems.groupsDraft.v3";
+const LEGACY_KEY_PREFIXES = ["wcp.pickems.groupsDraft.v2", "wcp.pickems.groupsDraft"];
 
 export function groupsDraftKey(userId: string | undefined): string {
   return `${KEY_PREFIX}.${userId ?? "anonymous"}`;
@@ -17,10 +23,22 @@ export function groupsDraftKey(userId: string | undefined): string {
 export function readGroupsDraft(userId: string | undefined): GroupsDraft | null {
   if (typeof window === "undefined") return null;
   try {
+    for (const prefix of LEGACY_KEY_PREFIXES) window.localStorage.removeItem(`${prefix}.${userId ?? "anonymous"}`);
     const raw = window.localStorage.getItem(groupsDraftKey(userId));
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? (parsed as GroupsDraft) : null;
+    if (!parsed || typeof parsed !== "object") return null;
+    const { base, data } = parsed as { base?: unknown; data?: unknown };
+    if (typeof base !== "string" || !data || typeof data !== "object") return null;
+    // Built on a server state that has since changed (e.g. saved from another
+    // device) — the draft is stale and the server wins.
+    const currentBase = getDraftBase("groups");
+    if (currentBase === null) return null;
+    if (base !== currentBase) {
+      window.localStorage.removeItem(groupsDraftKey(userId));
+      return null;
+    }
+    return data as GroupsDraft;
   } catch {
     return null;
   }
@@ -28,8 +46,10 @@ export function readGroupsDraft(userId: string | undefined): GroupsDraft | null 
 
 export function writeGroupsDraft(userId: string | undefined, draft: GroupsDraft): void {
   if (typeof window === "undefined") return;
+  const base = getDraftBase("groups");
+  if (base === null) return; // no server state seen yet — nothing to stamp against
   try {
-    window.localStorage.setItem(groupsDraftKey(userId), JSON.stringify(draft));
+    window.localStorage.setItem(groupsDraftKey(userId), JSON.stringify({ base, data: draft }));
   } catch {
     // ignore — storage may be unavailable (private mode, quota, etc.)
   }

--- a/src/features/pickems/lib/pickemStep.ts
+++ b/src/features/pickems/lib/pickemStep.ts
@@ -1,4 +1,4 @@
-import type { PickemStep } from "../types/pickems.types";
+import type { PickemStep, UserPickem } from "../types/pickems.types";
 
 export const PICKEM_STEPS: readonly PickemStep[] = ["groups", "thirds", "bracket"];
 
@@ -15,4 +15,18 @@ export function stepIndex(step: PickemStep): number {
 export function prevStep(step: PickemStep): PickemStep | null {
   const i = stepIndex(step);
   return i > 0 ? PICKEM_STEPS[i - 1] : null;
+}
+
+/**
+ * Returns the furthest step reachable given the server-committed pickem state
+ * (no local draft overlay). Used on load to detect when the URL step is ahead
+ * of what the server data actually supports — e.g. the user completed and
+ * submitted on mobile while this device still has `?step=bracket` in the URL.
+ */
+export function highestValidStep(data: UserPickem): PickemStep {
+  if (data.is_locked) return "bracket";
+  const groupsDone = data.group_picks.length > 0 && data.group_picks.every((g) => g.locked);
+  if (!groupsDone) return "groups";
+  if (data.best_thirds.length < 8) return "thirds";
+  return "bracket";
 }

--- a/src/features/pickems/lib/projectBracket.ts
+++ b/src/features/pickems/lib/projectBracket.ts
@@ -89,12 +89,15 @@ export function findChampion(bracket: BracketMatchSlot[]): Team | null {
 /**
  * Stable string identity of a bracket's picks (one `matchId:fifaCode` per slot,
  * empty when unpicked). Used to tell whether the locally-projected board differs
- * from what's already committed on the server — i.e. whether there's anything to
- * auto-save. Both inputs come from the same server array order, so a plain map is
- * order-stable; no sort needed.
+ * from what's already committed on the server (auto-save gate) and as the draft
+ * staleness baseline (see `draftBaseline`). The latter compares signatures across
+ * separate server responses, so sort by match_id rather than trusting array order.
  */
 export function bracketSignature(bracket: BracketMatchSlot[]): string {
-  return bracket.map((slot) => `${slot.match_id}:${slot.picked_team?.fifa_code ?? ""}`).join(",");
+  return [...bracket]
+    .sort((a, b) => a.match_id - b.match_id)
+    .map((slot) => `${slot.match_id}:${slot.picked_team?.fifa_code ?? ""}`)
+    .join(",");
 }
 
 /**

--- a/src/features/schedule/lib/buildScheduleJsonLd.ts
+++ b/src/features/schedule/lib/buildScheduleJsonLd.ts
@@ -1,0 +1,30 @@
+import type { Match } from "@/features/schedule/types/schedule.types";
+import { getTeamName } from "@/shared/lib/getTeamName";
+
+export function buildScheduleJsonLd(matches: Match[], locale: string): { "@context": string; "@graph": unknown[] } {
+  const graph: unknown[] = matches
+    .filter((m) => m.teams.home !== null && m.teams.away !== null)
+    .map((m) => {
+      const home = getTeamName(m.teams.home!, locale);
+      const away = getTeamName(m.teams.away!, locale);
+      return {
+        "@type": "SportsEvent",
+        name: `${home} vs ${away}`,
+        startDate: m.kickoff_at,
+        location: {
+          "@type": "Place",
+          name: m.venue.name,
+          address: {
+            "@type": "PostalAddress",
+            addressLocality: m.venue.city,
+          },
+        },
+        competitor: [
+          { "@type": "SportsTeam", name: home },
+          { "@type": "SportsTeam", name: away },
+        ],
+      };
+    });
+
+  return { "@context": "https://schema.org", "@graph": graph };
+}

--- a/src/i18n/messages/layout/es.json
+++ b/src/i18n/messages/layout/es.json
@@ -65,7 +65,7 @@
     "howItWorks": {
       "title": "Cómo funciona",
       "eyebrow": "Cómo empezar",
-      "intro": "Pick'ems es el juego definitivo de pronósticos del Mundial 2026. Compite con tus amigos prediciendo resultados, posiciones de grupos y el cuadro de eliminatorias.",
+      "intro": "La quiniela del Mundial 2026 que te faltaba. Pronostica cada partido, arma la polla con tus amigos y compite en tiempo real.",
       "steps": {
         "createAccount": {
           "title": "Crea tu cuenta",
@@ -210,7 +210,7 @@
       "items": {
         "whatIs": {
           "question": "¿Qué es Pick'ems?",
-          "answer": "Pick'ems es un juego gratuito de pronósticos para el Mundial FIFA 2026. Predices marcadores, posiciones de grupos y el cuadro de eliminatorias, y compites con amigos en clasificaciones. Más información en <howItWorksLink>Cómo funciona</howItWorksLink>."
+          "answer": "Pick'ems es un juego gratuito de pronósticos del Mundial FIFA 2026 (en México quiniela, en Argentina prode, en Colombia, Chile, Perú y Venezuela polla, en España porra). Predices marcadores, posiciones de grupos y el cuadro de eliminatorias, y compites con amigos en clasificaciones. Más información en <howItWorksLink>Cómo funciona</howItWorksLink>."
         },
         "howToPlay": {
           "question": "¿Cómo juego?",

--- a/src/i18n/messages/pickems/en.json
+++ b/src/i18n/messages/pickems/en.json
@@ -87,6 +87,7 @@
     "lockAllGroupsFirst": "Lock all 12 groups before continuing",
     "selectAllThirdsFirst": "Pick all 8 best thirds before continuing",
     "finishRoundFirst": "Finish this round before continuing",
-    "pickAllBracketFirst": "Pick all 32 winners before submitting"
+    "pickAllBracketFirst": "Pick all 32 winners before submitting",
+    "crossDeviceStepReset": "Your picks were updated from another device"
   }
 }

--- a/src/i18n/messages/pickems/es.json
+++ b/src/i18n/messages/pickems/es.json
@@ -87,6 +87,7 @@
     "lockAllGroupsFirst": "Confirma los 12 grupos antes de continuar",
     "selectAllThirdsFirst": "Elige los 8 mejores terceros antes de continuar",
     "finishRoundFirst": "Termina esta ronda antes de continuar",
-    "pickAllBracketFirst": "Elige los 32 ganadores antes de guardar tus picks"
+    "pickAllBracketFirst": "Elige los 32 ganadores antes de guardar tus picks",
+    "crossDeviceStepReset": "Tus picks fueron actualizados desde otro dispositivo"
   }
 }

--- a/src/i18n/messages/seo/en.json
+++ b/src/i18n/messages/seo/en.json
@@ -34,5 +34,9 @@
   "faq": {
     "title": "FAQ — World Cup 2026 Pick'ems",
     "description": "Frequently asked questions about Pick'ems: how to play, scoring rules, boards, and everything you need to know about the World Cup 2026 prediction game."
+  },
+  "bracket": {
+    "title": "Bracket — World Cup 2026 Knockout Stage",
+    "description": "View the FIFA World Cup 2026 knockout bracket: round of 32, round of 16, quarterfinals, semifinals and the final. Follow your Pick'ems predictions match by match."
   }
 }

--- a/src/i18n/messages/seo/es.json
+++ b/src/i18n/messages/seo/es.json
@@ -1,19 +1,19 @@
 {
   "home": {
     "title": "Pick'ems — Quiniela y Pronósticos del Mundial 2026 Gratis",
-    "description": "Juega la quiniela del Mundial 2026: pronostica los marcadores, arma tu llave y compite con amigos en tablas en vivo. Gratis."
+    "description": "La quiniela del Mundial 2026 más completa (prode en Argentina, porra en España, polla en Latam): pronostica marcadores, compite con amigos en tableros en vivo. Gratis."
   },
   "schedule": {
     "title": "Calendario del Mundial 2026 — Fechas, Horarios y Grupos",
-    "description": "Calendario completo del Mundial FIFA 2026: fechas, horarios, sedes y grupos. Pronostica cada marcador antes del inicio y sube en la tabla."
+    "description": "Consulta el calendario completo del Mundial FIFA 2026 y pronostica cada marcador antes del pitazo. No te quedes atrás en tu quiniela."
   },
   "standings": {
     "title": "Posiciones del Mundial 2026 — Tablas de Grupos en Vivo",
     "description": "Tabla de posiciones del Mundial FIFA 2026 en vivo: puntos, diferencia de gol y clasificados. Compara las tablas reales con tus pronósticos del pick'em."
   },
   "howItWorks": {
-    "title": "Cómo Jugar — Pronósticos del Mundial 2026",
-    "description": "Aprende cómo funciona Pick'ems: pronostica los grupos, arma tu llave del Mundial 2026, acierta los marcadores y suma puntos en tablas compartidas."
+    "title": "Cómo Jugar la Quiniela del Mundial 2026",
+    "description": "Domina tu quiniela del Mundial 2026: pronostica grupos, llena el bracket, acierta marcadores y deja a tus amigos sin excusas."
   },
   "rules": {
     "title": "Reglas y Puntuación — Mundial 2026",
@@ -33,6 +33,10 @@
   },
   "faq": {
     "title": "FAQ — Pick'ems del Mundial 2026",
-    "description": "Preguntas frecuentes sobre Pick'ems: cómo jugar, reglas de puntuación, tableros y todo lo que necesitas saber sobre el juego de pronósticos del Mundial 2026."
+    "description": "Todo lo que necesitas para tu polla mundialista del Mundial 2026: cómo jugar, puntuación, tableros y cómo dejar a tus amigos sin argumentos."
+  },
+  "bracket": {
+    "title": "Eliminatorias — Fase Final del Mundial 2026",
+    "description": "Sigue las eliminatorias del Mundial FIFA 2026: ronda de 32, octavos, cuartos, semifinales y la gran final. Compara el resultado real con tus pronósticos del Pick'ems."
   }
 }

--- a/src/shared/seo/breadcrumbs.ts
+++ b/src/shared/seo/breadcrumbs.ts
@@ -1,0 +1,11 @@
+export function buildBreadcrumbJsonLd(items: Array<{ name: string; url: string }>, _: string): Record<string, unknown> {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map(({ name, url }, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name,
+      item: url,
+    })),
+  };
+}


### PR DESCRIPTION
## Release v1.2.3

SEO/metadata improvements and two pick'em draft-sync fixes.

### Highlights
- Enhance sitemap and page metadata with structured data and localized content (#91)

### Fixes
- Discard stale local drafts when server state has changed (#92)
- Redirect to the correct step when server state is behind the URL (#93)