### PR TITLE
fix: forward real client IP on Google OAuth sign-in start

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,10 +21,7 @@ const nextConfig: NextConfig = {
         { source: "/api/auth/logout/all", destination: `${upstream}/api/auth/logout/all` },
         { source: "/api/auth/sessions", destination: `${upstream}/api/auth/sessions` },
         { source: "/api/auth/sessions/:id", destination: `${upstream}/api/auth/sessions/:id` },
-        // /api/oauth/google/callback is omitted — it has a dedicated route handler that
-        // reconciles the refresh-token cookie (rewrites to Path=/ and clears Path=/api/auth)
-        // so a stale previous-session cookie can't survive an OAuth login.
-        { source: "/api/oauth/:path((?!google/callback).*)", destination: `${upstream}/api/oauth/:path*` },
+        { source: "/api/oauth/:path((?!google).*)", destination: `${upstream}/api/oauth/:path*` },
       ],
 
       // Non-auth API routes are proxied by the catch-all route handler at

--- a/src/app/api/oauth/google/route.ts
+++ b/src/app/api/oauth/google/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { forwardedClientHeaders } from "@/shared/lib/api/forwarded-headers";
+
+const UPSTREAM = process.env.BACKEND_API_URL!;
+
+export async function GET(req: NextRequest) {
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${UPSTREAM}/api/oauth/google${req.nextUrl.search}`, {
+      method: "GET",
+      headers: { ...forwardedClientHeaders(req) },
+      redirect: "manual",
+    });
+  } catch {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+
+  const location = upstream.headers.get("location");
+  if (upstream.status >= 300 && upstream.status < 400 && location) {
+    return NextResponse.redirect(new URL(location, req.url));
+  }
+
+  return NextResponse.redirect(new URL("/login", req.url));
+}


### PR DESCRIPTION
## Related issue

_No linked issue._

## What changed

- Add a Node-runtime route handler for `/api/oauth/google` so the OAuth sign-in start attaches the trusted `X-Client-IP` header (a `next.config` rewrite drops proxy-set headers).
- Exclude `/api/oauth/google` from the rewrite lookahead (`(?!google)`) so it doesn't shadow the new handler — `beforeFiles` runs before route handlers.
- Backend now resolves each user's real IP on sign-in start instead of this server's egress IP, fixing the shared per-IP rate-limit bucket that 429'd the entire userbase.

## How to test

- [ ] Click "Sign in with Google" and confirm a full redirect → `accounts.google.com` → callback → logged in.
- [ ] In API prod logs, confirm `GET /api/oauth/google` now logs the client's real IP, not `152.55.180.106`.
- [ ] Sign in from two different networks; confirm each shows its own IP in the logs.
- [ ] Exhaust the sign-in limit from one IP; confirm a second IP is unaffected (buckets isolated).