### PR TITLE
feat(boards): view a member's picks, awards & matches from the board

### DIFF
--- a/src/app/[locale]/boards/[boardId]/members/[userId]/loading.tsx
+++ b/src/app/[locale]/boards/[boardId]/members/[userId]/loading.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from "@/shared/components/ui/skeleton";
+
+// Mirrors the member view: back link, identity header, tabs, then the first
+// (Groups) section grid — so nothing shifts when the data resolves.
+export default function MemberPicksLoading() {
+  return (
+    <section className="container flex flex-col gap-6 pt-6 pb-10 lg:pt-8 lg:pb-12">
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-5 w-40" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-11 rounded-full" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-7 w-44" />
+            <Skeleton className="h-4 w-28" />
+          </div>
+        </div>
+        <Skeleton className="h-4 w-64" />
+      </div>
+
+      <div className="flex gap-4 border-b border-border pb-2">
+        <Skeleton className="h-5 w-16" />
+        <Skeleton className="h-5 w-16" />
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-7 w-32" />
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 lg:gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-40 rounded-xl" />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/[locale]/boards/[boardId]/members/[userId]/page.tsx
+++ b/src/app/[locale]/boards/[boardId]/members/[userId]/page.tsx
@@ -1,0 +1,101 @@
+import { notFound } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
+import type { UserAwards } from "@/features/awards/types/awards.types";
+import { BOARDS_LIST_TAG, boardMembersTag } from "@/features/boards/api/boards";
+import { memberAwardsTag, memberPickemTag } from "@/features/boards/api/memberPicks";
+import { MemberPicksView } from "@/features/boards/components/MemberPicksView";
+import type { BoardListItem, BoardMember } from "@/features/boards/types/boards.types";
+import type { UserPickem } from "@/features/pickems/types/pickems.types";
+import { MATCHES_CACHE_TAG } from "@/features/schedule/api/matches";
+import type { Match } from "@/features/schedule/types/schedule.types";
+import { STANDINGS_CACHE_TAG } from "@/features/standings/api/standings";
+import type { StandingRow } from "@/features/standings/types/standings.types";
+import { redirect } from "@/i18n/navigation";
+import { getCurrentUser } from "@/lib/auth";
+import { serverApi } from "@/shared/lib/api/server";
+
+type Props = {
+  params: Promise<{ boardId: string; userId: string }>;
+  // `n` (display name) + `u` (@handle) carried by the leaderboard link so the
+  // header titles itself correctly even when the roster lookup misses.
+  searchParams: Promise<{ n?: string; u?: string }>;
+};
+
+export default async function BoardMemberPage({ params, searchParams }: Props) {
+  const [{ boardId, userId }, sp, user, locale] = await Promise.all([params, searchParams, getCurrentUser(), getLocale()]);
+  if (!user) notFound();
+
+  const boardIdNum = Number(boardId);
+  if (!Number.isFinite(boardIdNum)) notFound();
+
+  // Viewing your own picks here is redundant — send you to the editable surface.
+  if (userId === user.id) redirect({ href: "/pickems", locale });
+
+  const [boardsRes, membersRes, pickemRes, awardsRes, standingsRes, matchesRes] = await Promise.all([
+    serverApi.get<BoardListItem[]>("/api/boards", { authenticated: true, next: { revalidate: 30, tags: [BOARDS_LIST_TAG] } }),
+    serverApi.get<BoardMember[]>(`/api/boards/${boardIdNum}/members?limit=100`, { authenticated: true, next: { revalidate: 30, tags: [boardMembersTag(boardIdNum)] } }),
+    serverApi.get<UserPickem>(`/api/boards/${boardIdNum}/members/${userId}/pickem`, {
+      authenticated: true,
+      next: { revalidate: 60, tags: [memberPickemTag(boardIdNum, userId)] },
+    }),
+    serverApi.get<UserAwards>(`/api/boards/${boardIdNum}/members/${userId}/awards`, {
+      authenticated: true,
+      next: { revalidate: 60, tags: [memberAwardsTag(boardIdNum, userId)] },
+    }),
+    // Actual results the member's predictions are scored against (compare mode).
+    serverApi.get<StandingRow[]>("/api/standings", { authenticated: false, next: { revalidate: 60, tags: [STANDINGS_CACHE_TAG] } }),
+    serverApi.get<Match[]>("/api/matches", { authenticated: Boolean(user), next: { revalidate: 60, tags: [MATCHES_CACHE_TAG] } }),
+  ]);
+
+  if (!boardsRes.success) throw new Error(boardsRes.error?.message ?? "Failed to load boards");
+  const boards = boardsRes.data ?? [];
+  const board = boards.find((b) => b.id === boardIdNum);
+  // Not a member of this board (removed, or a stale link) → bounce like the board page does.
+  if (!board) {
+    const fallback = boards.find((b) => b.privacy === "global") ?? boards[0];
+    if (fallback) redirect({ href: `/boards/${fallback.id}?notice=board-not-found`, locale });
+    notFound();
+  }
+
+  // The endpoints only reveal a member's picks after kickoff (they 403 before).
+  // Rather than bouncing the viewer back — which reads as a broken navigation —
+  // we render the member view and let it show an "not available yet" state.
+
+  // Prefer the roster lookup (full identity, incl. role). When it misses — the
+  // members list is paginated and large boards exceed one page — fall back to
+  // the name carried in the link so the header isn't a generic "Member".
+  const looked = membersRes.success ? (membersRes.data ?? []).find((m) => m.user_id === userId) : undefined;
+  const member: BoardMember | null = looked ?? buildMemberFromQuery(userId, sp);
+
+  return (
+    <MemberPicksView
+      boardId={boardIdNum}
+      boardName={board.name}
+      userId={userId}
+      member={member ?? null}
+      initialPickem={pickemRes.success ? (pickemRes.data ?? null) : null}
+      initialAwards={awardsRes.success ? (awardsRes.data ?? null) : null}
+      standings={standingsRes.success ? (standingsRes.data ?? []) : []}
+      matches={matchesRes.success ? (matchesRes.data ?? []) : []}
+    />
+  );
+}
+
+// Build a roster-shaped member from the link's display name + handle so the
+// header reads correctly without a successful roster lookup. The name is split
+// into first/last so `displayName`/`getInitials` reproduce it; role isn't in the
+// link, so it defaults to "member" (only used in the rare lookup-miss path).
+function buildMemberFromQuery(userId: string, sp: { n?: string; u?: string }): BoardMember | null {
+  const name = sp.n?.trim();
+  if (!name) return null;
+  const parts = name.split(/\s+/);
+  return {
+    user_id: userId,
+    username: sp.u?.trim() ?? "",
+    first_name: parts[0] || null,
+    last_name: parts.length > 1 ? parts.slice(1).join(" ") : null,
+    role: "member",
+    joined_at: "",
+  };
+}

--- a/src/features/boards/api/memberPicks.ts
+++ b/src/features/boards/api/memberPicks.ts
@@ -1,0 +1,32 @@
+import type { UserAwards } from "@/features/awards/types/awards.types";
+import type { UserPickem } from "@/features/pickems/types/pickems.types";
+import { api } from "@/shared/lib/api/client";
+import { ApiClientError } from "@/shared/lib/api/errors";
+import type { ApiResponse } from "@/shared/lib/api/types";
+
+// Board-scoped reads of another member's committed predictions. Both endpoints
+// return the same bare domain objects as the viewer's own `/pickems` and
+// `/awards` (no member-info wrapping), so the existing read-only renderers
+// consume them directly. The member's identity comes from the board roster.
+
+// Cache tags for the RSC fetch (server side); keep them per-member so a future
+// revalidation can target a single member without dumping the whole board.
+export const memberPickemTag = (boardId: number, userId: string) => `boards:${boardId}:member:${userId}:pickem` as const;
+export const memberAwardsTag = (boardId: number, userId: string) => `boards:${boardId}:member:${userId}:awards` as const;
+
+// TanStack Query keys for the client hooks seeded from the server `initialData`.
+export const memberPickemKey = (boardId: number, userId: string) => ["boards", boardId, "member", userId, "pickem"] as const;
+export const memberAwardsKey = (boardId: number, userId: string) => ["boards", boardId, "member", userId, "awards"] as const;
+
+function unwrap<T>(res: ApiResponse<T>, fallback: string): T {
+  if (res.success && res.data !== undefined) return res.data;
+  throw new ApiClientError(res.error?.code ?? "UNKNOWN_ERROR", res.error?.message ?? fallback);
+}
+
+export async function fetchMemberPickem(boardId: number, userId: string): Promise<UserPickem> {
+  return unwrap(await api.get<UserPickem>(`/api/boards/${boardId}/members/${userId}/pickem`, { authenticated: true }), "Failed to load member pick'em");
+}
+
+export async function fetchMemberAwards(boardId: number, userId: string): Promise<UserAwards> {
+  return unwrap(await api.get<UserAwards>(`/api/boards/${boardId}/members/${userId}/awards`, { authenticated: true }), "Failed to load member awards");
+}

--- a/src/features/boards/components/ManageBoardMembers.tsx
+++ b/src/features/boards/components/ManageBoardMembers.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronLeft, ChevronRight, Crown, Search, ShieldOff, ShieldUser, UserX } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight, Crown, Eye, Search, ShieldOff, ShieldUser, UserX } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
+import { hasTournamentStarted } from "@/features/dashboard/lib/tournamentConfig";
+import { Link } from "@/i18n/navigation";
 import { Button } from "@/shared/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
 import { Input } from "@/shared/components/ui/input";
@@ -61,6 +63,8 @@ export function ManageBoardMembers({ board, currentUserId, enabled, onPermission
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const viewerRole = board.viewer.role;
   const canManage = canManageBoard(viewerRole);
+  // Other members' picks only become viewable once the tournament has started.
+  const tournamentStarted = hasTournamentStarted();
 
   function handlePromote(member: BoardMember) {
     updateRole.mutateAsync({ userId: member.user_id, role: "admin" }).then(() => toast.success(t("promoted")), reportError);
@@ -118,10 +122,15 @@ export function ManageBoardMembers({ board, currentUserId, enabled, onPermission
             const canActOnTarget = viewerRole === "owner" || member.role === "member";
             const showActions = canManage && !isSelf && member.role !== "owner" && canActOnTarget;
             const isOpen = expandedId === member.user_id;
+            // "View picks" is available to everyone (after kickoff) for any other
+            // member; the manage actions stay gated by `showActions`. The chevron
+            // appears whenever the panel has at least one option.
+            const canViewPicks = tournamentStarted && !isSelf;
+            const hasPanel = canViewPicks || showActions;
 
             return (
               <li key={member.user_id} className={cn("overflow-hidden rounded-lg border bg-card transition-colors", isOpen && "border-page-accent/40")}>
-                {showActions ? (
+                {hasPanel ? (
                   <button
                     type="button"
                     onClick={() => setExpandedId(isOpen ? null : member.user_id)}
@@ -142,50 +151,62 @@ export function ManageBoardMembers({ board, currentUserId, enabled, onPermission
                   </div>
                 )}
 
-                {showActions && isOpen ? (
+                {hasPanel && isOpen ? (
                   <div className="flex flex-col gap-0.5 border-t border-border/60 bg-muted/40 p-1.5">
-                    {member.role === "member" ? (
+                    {canViewPicks ? (
                       <MemberActionRow
-                        icon={ShieldUser}
-                        title={t("promote")}
-                        subtitle={t("promoteSubtitle")}
-                        onClick={() => {
-                          setExpandedId(null);
-                          handlePromote(member);
-                        }}
-                      />
-                    ) : (
-                      <MemberActionRow
-                        icon={ShieldOff}
-                        title={t("demote")}
-                        subtitle={t("demoteSubtitle")}
-                        onClick={() => {
-                          setExpandedId(null);
-                          handleDemote(member);
-                        }}
-                      />
-                    )}
-                    {viewerRole === "owner" ? (
-                      <MemberActionRow
-                        icon={Crown}
-                        title={t("transfer")}
-                        subtitle={t("transferSubtitle")}
-                        onClick={() => {
-                          setExpandedId(null);
-                          setTransferTarget(member);
-                        }}
+                        icon={Eye}
+                        title={t("viewPicks")}
+                        subtitle={t("viewPicksSubtitle")}
+                        href={`/boards/${board.id}/members/${member.user_id}?n=${encodeURIComponent(displayName)}&u=${encodeURIComponent(member.username)}`}
                       />
                     ) : null}
-                    <MemberActionRow
-                      icon={UserX}
-                      title={t("remove")}
-                      subtitle={t("removeSubtitle")}
-                      tone="destructive"
-                      onClick={() => {
-                        setExpandedId(null);
-                        setRemoveTarget(member);
-                      }}
-                    />
+                    {showActions ? (
+                      <>
+                        {member.role === "member" ? (
+                          <MemberActionRow
+                            icon={ShieldUser}
+                            title={t("promote")}
+                            subtitle={t("promoteSubtitle")}
+                            onClick={() => {
+                              setExpandedId(null);
+                              handlePromote(member);
+                            }}
+                          />
+                        ) : (
+                          <MemberActionRow
+                            icon={ShieldOff}
+                            title={t("demote")}
+                            subtitle={t("demoteSubtitle")}
+                            onClick={() => {
+                              setExpandedId(null);
+                              handleDemote(member);
+                            }}
+                          />
+                        )}
+                        {viewerRole === "owner" ? (
+                          <MemberActionRow
+                            icon={Crown}
+                            title={t("transfer")}
+                            subtitle={t("transferSubtitle")}
+                            onClick={() => {
+                              setExpandedId(null);
+                              setTransferTarget(member);
+                            }}
+                          />
+                        ) : null}
+                        <MemberActionRow
+                          icon={UserX}
+                          title={t("remove")}
+                          subtitle={t("removeSubtitle")}
+                          tone="destructive"
+                          onClick={() => {
+                            setExpandedId(null);
+                            setRemoveTarget(member);
+                          }}
+                        />
+                      </>
+                    ) : null}
                   </div>
                 ) : null}
               </li>
@@ -259,23 +280,23 @@ function MemberActionRow({
   subtitle,
   onClick,
   tone = "default",
+  href,
 }: {
   icon: ActionIcon;
   title: string;
   subtitle: string;
-  onClick: () => void;
+  onClick?: () => void;
   tone?: "default" | "destructive";
+  /** When set, the row navigates (used by "View picks") instead of firing onClick. */
+  href?: string;
 }) {
   const destructive = tone === "destructive";
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "flex w-full min-w-0 items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors hover:bg-card focus-visible:bg-card focus-visible:outline-none",
-        destructive && "hover:bg-destructive/5 focus-visible:bg-destructive/5"
-      )}
-    >
+  const className = cn(
+    "flex w-full min-w-0 items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors hover:bg-card focus-visible:bg-card focus-visible:outline-none",
+    destructive && "hover:bg-destructive/5 focus-visible:bg-destructive/5"
+  );
+  const inner = (
+    <>
       <span className={cn("grid size-8 shrink-0 place-items-center rounded-md", destructive ? "bg-destructive/10" : "bg-page-accent-soft")}>
         <Icon className={cn("size-4", destructive ? "text-destructive" : "text-page-accent-strong")} aria-hidden />
       </span>
@@ -283,6 +304,20 @@ function MemberActionRow({
         <span className={cn("truncate text-sm font-medium", destructive && "text-destructive")}>{title}</span>
         <span className="truncate text-2xs text-muted-foreground">{subtitle}</span>
       </span>
+      {href ? <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden /> : null}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={className}>
+        {inner}
+      </Link>
+    );
+  }
+  return (
+    <button type="button" onClick={onClick} className={className}>
+      {inner}
     </button>
   );
 }

--- a/src/features/boards/components/MemberAwardsGrid.tsx
+++ b/src/features/boards/components/MemberAwardsGrid.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { AwardCard } from "@/features/awards/components/AwardCard";
+import { AWARD_TYPES, findPick } from "@/features/awards/lib/awards";
+import type { UserAwards } from "@/features/awards/types/awards.types";
+
+const noop = () => {};
+
+type Props = { awards: UserAwards };
+
+/**
+ * Read-only grid of another member's award picks. Reuses `AwardCard` in its
+ * locked state (no select / clear), so it renders identically to the owner's
+ * own locked awards.
+ */
+export function MemberAwardsGrid({ awards }: Props) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {AWARD_TYPES.map((awardType) => (
+        <AwardCard key={awardType} awardType={awardType} pick={findPick(awards.picks, awardType)} isLocked onSelect={noop} onClear={noop} />
+      ))}
+    </div>
+  );
+}

--- a/src/features/boards/components/MemberPickemSections.tsx
+++ b/src/features/boards/components/MemberPickemSections.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useMemo } from "react";
+import { ListOrdered, Trophy } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { BracketCompareLegend } from "@/features/bracket/components/BracketCompareLegend";
+import { buildComparisonMap, summarizeBracket } from "@/features/bracket/lib/bracketCompare";
+import { buildActualBracket } from "@/features/bracket/lib/buildActualBracket";
+import { BracketTree } from "@/features/pickems/components/BracketTree";
+import { findChampion, projectBracket } from "@/features/pickems/lib/projectBracket";
+import type { UserPickem } from "@/features/pickems/types/pickems.types";
+import type { Match } from "@/features/schedule/types/schedule.types";
+import { ComparisonLegend } from "@/features/standings/components/ComparisonLegend";
+import { GroupCard as StandingsGroupCard } from "@/features/standings/components/GroupCard";
+import { ThirdPlaceCard } from "@/features/standings/components/ThirdPlaceCard";
+import { buildBestThirdsSet, buildPickIndex, summarizeGroupStage } from "@/features/standings/lib/comparison";
+import { groupAndEnrichStandings } from "@/features/standings/lib/groupStandings";
+import { buildThirdPlaceStandings } from "@/features/standings/lib/thirdPlace";
+import type { StandingRow } from "@/features/standings/types/standings.types";
+
+const NO_DRAFT = {};
+
+type Props = {
+  pickem: UserPickem;
+  standings: StandingRow[];
+  matches: Match[];
+};
+
+/**
+ * Another member's pick'em shown in COMPARE mode — their predictions measured
+ * against the actual results, with the points they earn. Reuses the standings
+ * and bracket compare primitives (same scoring the viewer sees on their own
+ * `/standings` and `/bracket`), so there's no duplicated logic; only the pickem
+ * source differs (this member's, not the viewer's).
+ */
+export function MemberPickemSections({ pickem, standings, matches }: Props) {
+  const t = useTranslations("boards.member");
+
+  // Group-standings compare: the member's group order vs the real table.
+  const groups = useMemo(() => groupAndEnrichStandings(standings), [standings]);
+  const thirdPlace = useMemo(() => buildThirdPlaceStandings(groups), [groups]);
+  const pickIndex = useMemo(() => buildPickIndex(pickem), [pickem]);
+  const bestThirds = useMemo(() => buildBestThirdsSet(pickem), [pickem]);
+  const groupSummary = useMemo(() => summarizeGroupStage(groups, pickIndex), [groups, pickIndex]);
+
+  // Bracket compare: the member's knockout predictions vs the real bracket.
+  const actualSlots = useMemo(() => buildActualBracket(matches), [matches]);
+  const predictedSlots = useMemo(() => projectBracket(pickem.bracket, NO_DRAFT), [pickem.bracket]);
+  const champion = useMemo(() => findChampion(actualSlots), [actualSlots]);
+  const comparisonById = useMemo(() => buildComparisonMap(actualSlots, predictedSlots), [actualSlots, predictedSlots]);
+  const summary = useMemo(() => summarizeBracket(actualSlots, predictedSlots), [actualSlots, predictedSlots]);
+
+  return (
+    <div className="flex flex-col gap-10">
+      <Section icon={ListOrdered} title={t("sections.groups")}>
+        <ComparisonLegend summary={groupSummary} />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {groups.map((group) => (
+            <StandingsGroupCard key={group.group_code} group={group} pickIndex={pickIndex} />
+          ))}
+        </div>
+        <ThirdPlaceCard standings={thirdPlace} bestThirds={bestThirds} />
+      </Section>
+
+      <Section icon={Trophy} title={t("sections.bracket")}>
+        {summary.possible > 0 ? <BracketCompareLegend summary={summary} /> : null}
+        <BracketTree bracket={actualSlots} champion={champion} disabled comparisonById={comparisonById} />
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  icon: Icon,
+  title,
+  children,
+}: {
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-page-accent-soft">
+          <Icon className="size-4 text-page-accent-strong" aria-hidden />
+        </span>
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">{title}</h2>
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/src/features/boards/components/MemberPicksHeader.tsx
+++ b/src/features/boards/components/MemberPicksHeader.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { ChevronLeft } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Link } from "@/i18n/navigation";
+import { displayName, getInitials } from "@/shared/lib/ui";
+
+import type { BoardMember } from "../types/boards.types";
+
+import { RoleChip } from "./RoleChip";
+
+type Props = {
+  boardId: number;
+  boardName: string;
+  member: BoardMember | null;
+};
+
+export function MemberPicksHeader({ boardId, boardName, member }: Props) {
+  const t = useTranslations("boards.member");
+
+  const name = member ? displayName(member.username, member.first_name, member.last_name) : t("fallbackName");
+  const initials = member ? getInitials(member.username, member.first_name ?? undefined, member.last_name ?? undefined) : "—";
+
+  return (
+    <header className="flex flex-col gap-4">
+      <Link
+        href={`/boards/${boardId}?tab=members`}
+        className="inline-flex w-fit items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" aria-hidden />
+        {t("back", { board: boardName })}
+      </Link>
+
+      <div className="flex items-center gap-3">
+        <span className="grid size-11 shrink-0 place-items-center rounded-full bg-page-accent-soft text-sm font-semibold text-page-accent-strong">{initials}</span>
+        <div className="flex min-w-0 flex-col">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <h1 className="truncate text-2xl font-bold tracking-tight sm:text-3xl">{name}</h1>
+            {member ? <RoleChip role={member.role} /> : null}
+          </div>
+          {member ? <span className="truncate text-sm text-muted-foreground">@{member.username}</span> : null}
+        </div>
+      </div>
+
+      <p className="text-sm text-muted-foreground">{t("subtitle", { name })}</p>
+    </header>
+  );
+}

--- a/src/features/boards/components/MemberPicksView.tsx
+++ b/src/features/boards/components/MemberPicksView.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { CalendarClock } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+
+import type { UserAwards } from "@/features/awards/types/awards.types";
+import type { UserPickem } from "@/features/pickems/types/pickems.types";
+import type { Match } from "@/features/schedule/types/schedule.types";
+import type { StandingRow } from "@/features/standings/types/standings.types";
+import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
+import { cn } from "@/shared/lib/utils";
+
+import { useMemberAwards, useMemberPickem } from "../hooks/useMemberPicks";
+import type { BoardMember } from "../types/boards.types";
+
+import { MemberAwardsGrid } from "./MemberAwardsGrid";
+import { MemberPickemSections } from "./MemberPickemSections";
+import { MemberPicksHeader } from "./MemberPicksHeader";
+
+type MemberTab = "pickem" | "awards" | "matches";
+
+const TAB_PARAM = "tab";
+
+// Same active-accent underline as the board's own tabs, for visual continuity.
+const ACTIVE_ACCENT = cn(
+  "data-active:text-page-accent dark:data-active:text-page-accent",
+  "after:bg-page-accent",
+  "data-active:hover:text-page-accent-strong dark:data-active:hover:text-page-accent-strong",
+  "data-active:hover:after:bg-page-accent-strong"
+);
+
+type Props = {
+  boardId: number;
+  boardName: string;
+  userId: string;
+  member: BoardMember | null;
+  initialPickem: UserPickem | null;
+  initialAwards: UserAwards | null;
+  /** Actual results the member's predictions are scored against (compare mode). */
+  standings: StandingRow[];
+  matches: Match[];
+};
+
+export function MemberPicksView({ boardId, boardName, userId, member, initialPickem, initialAwards, standings, matches }: Props) {
+  const t = useTranslations("boards.member");
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const { data: pickem } = useMemberPickem(boardId, userId, initialPickem ?? undefined);
+  const { data: awards } = useMemberAwards(boardId, userId, initialAwards ?? undefined);
+
+  const param = searchParams.get(TAB_PARAM);
+  const tab: MemberTab = param === "awards" ? "awards" : param === "matches" ? "matches" : "pickem";
+
+  function setTab(next: MemberTab) {
+    const params = new URLSearchParams(searchParams);
+    if (next === "pickem") params.delete(TAB_PARAM);
+    else params.set(TAB_PARAM, next);
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }
+
+  const tabs: { key: MemberTab; label: string }[] = [
+    { key: "pickem", label: t("tabs.pickem") },
+    { key: "awards", label: t("tabs.awards") },
+    { key: "matches", label: t("tabs.matches") },
+  ];
+
+  return (
+    <section className="container flex flex-col gap-6 pt-6 pb-10 lg:pt-8 lg:pb-12">
+      <MemberPicksHeader boardId={boardId} boardName={boardName} member={member} />
+
+      <Tabs value={tab} onValueChange={(v) => setTab(v as MemberTab)}>
+        <TabsList variant="line" className="w-full justify-start gap-4">
+          {tabs.map((item) => (
+            <TabsTrigger key={item.key} value={item.key} className={cn("flex-none cursor-pointer px-0.5", ACTIVE_ACCENT)}>
+              {item.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {tab === "pickem" ? (
+        pickem ? (
+          <MemberPickemSections pickem={pickem} standings={standings} matches={matches} />
+        ) : (
+          <Unavailable label={t("picksUnavailable")} />
+        )
+      ) : tab === "awards" ? (
+        awards ? (
+          <MemberAwardsGrid awards={awards} />
+        ) : (
+          <Unavailable label={t("awardsUnavailable")} />
+        )
+      ) : (
+        // Matches: per-match predictions (played matches only). Endpoint not built
+        // yet — the tab is reserved with a "coming soon" placeholder.
+        <ComingSoon title={t("matchesSoonTitle")} hint={t("matchesSoonHint")} />
+      )}
+    </section>
+  );
+}
+
+function Unavailable({ label }: { label: string }) {
+  return <p className="rounded-xl border bg-muted p-8 text-center text-sm text-muted-foreground">{label}</p>;
+}
+
+function ComingSoon({ title, hint }: { title: string; hint: string }) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border bg-muted/30 px-6 py-16 text-center">
+      <span className="grid size-12 place-items-center rounded-full bg-page-accent-soft">
+        <CalendarClock className="size-6 text-page-accent-strong" aria-hidden />
+      </span>
+      <p className="text-base font-semibold text-foreground">{title}</p>
+      <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">{hint}</p>
+    </div>
+  );
+}

--- a/src/features/boards/hooks/useMemberPicks.ts
+++ b/src/features/boards/hooks/useMemberPicks.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import type { UserAwards } from "@/features/awards/types/awards.types";
+import type { UserPickem } from "@/features/pickems/types/pickems.types";
+
+import { fetchMemberAwards, fetchMemberPickem, memberAwardsKey, memberPickemKey } from "../api/memberPicks";
+
+// Seeded from the RSC `initialData`; the queryFn only runs on a client refetch.
+export function useMemberPickem(boardId: number, userId: string, initialData?: UserPickem) {
+  return useQuery({
+    queryKey: memberPickemKey(boardId, userId),
+    queryFn: () => fetchMemberPickem(boardId, userId),
+    initialData,
+  });
+}
+
+export function useMemberAwards(boardId: number, userId: string, initialData?: UserAwards) {
+  return useQuery({
+    queryKey: memberAwardsKey(boardId, userId),
+    queryFn: () => fetchMemberAwards(boardId, userId),
+    initialData,
+  });
+}

--- a/src/features/competitions/components/BoardSummaryTab.tsx
+++ b/src/features/competitions/components/BoardSummaryTab.tsx
@@ -16,6 +16,7 @@ import type { BoardSummaryEntry } from "../types/competitions.types";
 
 import { LeaderboardMobileTable, type MobileLeaderboardColumn } from "./LeaderboardMobileTable";
 import { LeaderboardPagination } from "./LeaderboardPagination";
+import { MemberNameLink } from "./MemberNameLink";
 
 // Which per-type subtotal columns the board has (custom = match competitions).
 export type SummaryColumn = "pickem" | "custom" | "pick" | "awards";
@@ -137,7 +138,7 @@ export function BoardSummaryTab({ boardId, currentUserId, columns, enabled }: Pr
                       <RankBadge rank={entry.rank} />
                     </td>
                     <td className="px-4 py-2.5">
-                      <MemberCell entry={entry} isMe={isMe} youLabel={t("you")} />
+                      <MemberCell entry={entry} isMe={isMe} youLabel={t("you")} boardId={boardId} currentUserId={currentUserId} />
                     </td>
                     {columns.map((col) => (
                       <td key={col} className="px-4 py-2.5 text-center text-muted-foreground">
@@ -155,6 +156,7 @@ export function BoardSummaryTab({ boardId, currentUserId, columns, enabled }: Pr
         {/* Mobile */}
         <div className="p-4 md:hidden">
           <LeaderboardMobileTable
+            boardId={boardId}
             rows={items}
             columns={mobileColumns}
             getMember={(row) => row.member}
@@ -210,10 +212,29 @@ function RankBadge({ rank }: { rank: number }) {
   return <span className="font-mono text-xs font-semibold text-muted-foreground">{rank}</span>;
 }
 
-function MemberCell({ entry, isMe, youLabel }: { entry: BoardSummaryEntry; isMe: boolean; youLabel: string }) {
+function MemberCell({
+  entry,
+  isMe,
+  youLabel,
+  boardId,
+  currentUserId,
+}: {
+  entry: BoardSummaryEntry;
+  isMe: boolean;
+  youLabel: string;
+  boardId: number;
+  currentUserId: string;
+}) {
   return (
     <span className="flex min-w-0 items-center gap-1.5">
-      <span className="min-w-0 truncate font-medium">{displayName(entry.member.username, entry.member.first_name, entry.member.last_name)}</span>
+      <MemberNameLink
+        boardId={boardId}
+        userId={entry.member.user_id}
+        currentUserId={currentUserId}
+        name={displayName(entry.member.username, entry.member.first_name, entry.member.last_name)}
+        username={entry.member.username}
+        className="font-medium"
+      />
       {isMe ? <span className="shrink-0 rounded-md bg-page-accent p-1 text-2xs font-medium uppercase tracking-wide text-white">{youLabel}</span> : null}
     </span>
   );

--- a/src/features/competitions/components/LeaderboardMobileTable.tsx
+++ b/src/features/competitions/components/LeaderboardMobileTable.tsx
@@ -11,6 +11,8 @@ import { cn } from "@/shared/lib/utils";
 
 import { LEADERBOARD_PAGE_SIZE } from "../api/competitions";
 
+import { MemberNameLink } from "./MemberNameLink";
+
 export type MobileLeaderboardMember = {
   user_id: string;
   username: string;
@@ -27,6 +29,7 @@ export type MobileLeaderboardColumn<T> = {
 };
 
 type Props<T> = {
+  boardId: number;
   rows: T[];
   columns: MobileLeaderboardColumn<T>[];
   getMember: (row: T) => MobileLeaderboardMember;
@@ -46,7 +49,7 @@ const GRID = "grid grid-cols-[2.25rem_1fr_7.5rem] items-center gap-3";
 // One metric is visible at a time: the arrows (or a swipe) cycle which column,
 // and the "Order" line flips the sort direction. Shared by the competition
 // leaderboard and the board summary so both read the same on mobile.
-export function LeaderboardMobileTable<T>({ rows, columns, getMember, getRank, currentUserId, isLoading, emptyLabel, sort, dir, onSort }: Props<T>) {
+export function LeaderboardMobileTable<T>({ boardId, rows, columns, getMember, getRank, currentUserId, isLoading, emptyLabel, sort, dir, onSort }: Props<T>) {
   const t = useTranslations("competitions.leaderboard");
 
   const activeIdx = Math.max(
@@ -140,9 +143,14 @@ export function LeaderboardMobileTable<T>({ rows, columns, getMember, getRank, c
                 <span className="text-center text-xs font-medium text-muted-foreground tabular-nums">{String(rank).padStart(2, "0")}</span>
                 <div className="flex min-w-0 flex-col leading-tight">
                   <span className="flex min-w-0 items-center gap-1.5">
-                    <span className={cn("truncate text-sm font-medium", isMe && "text-page-accent-strong")}>
-                      {displayName(member.username, member.first_name, member.last_name)}
-                    </span>
+                    <MemberNameLink
+                      boardId={boardId}
+                      userId={member.user_id}
+                      currentUserId={currentUserId}
+                      name={displayName(member.username, member.first_name, member.last_name)}
+                      username={member.username}
+                      className={cn("text-sm font-medium", isMe && "text-page-accent-strong")}
+                    />
                     {isMe ? <span className="rounded-md bg-page-accent p-1 text-2xs font-medium tracking-wide text-white uppercase">{t("you")}</span> : null}
                   </span>
                   <span className="truncate text-xs text-muted-foreground">@{member.username}</span>

--- a/src/features/competitions/components/LeaderboardSection.tsx
+++ b/src/features/competitions/components/LeaderboardSection.tsx
@@ -88,6 +88,7 @@ export function LeaderboardSection({ boardId, competition, currentUserId, initia
     <div className="overflow-hidden rounded-xl border border-foreground/10 bg-card shadow-xs">
       <div className="hidden md:block">
         <LeaderboardTable
+          boardId={boardId}
           columns={columns}
           rows={items}
           currentUserId={currentUserId}
@@ -100,6 +101,7 @@ export function LeaderboardSection({ boardId, competition, currentUserId, initia
       </div>
       <div className="p-4 md:hidden">
         <LeaderboardMobileTable
+          boardId={boardId}
           rows={items}
           columns={mobileColumns}
           getMember={(row) => row.member}

--- a/src/features/competitions/components/LeaderboardTable.tsx
+++ b/src/features/competitions/components/LeaderboardTable.tsx
@@ -11,7 +11,10 @@ import { cn } from "@/shared/lib/utils";
 import { LEADERBOARD_PAGE_SIZE } from "../api/competitions";
 import type { LeaderboardEntry } from "../types/competitions.types";
 
+import { MemberNameLink } from "./MemberNameLink";
+
 type Props = {
+  boardId: number;
   columns: ColumnDef<LeaderboardEntry>[];
   rows: LeaderboardEntry[];
   currentUserId: string;
@@ -22,7 +25,7 @@ type Props = {
   onSort: (key: string) => void;
 };
 
-export function LeaderboardTable({ columns, rows, currentUserId, isLoading, emptyLabel, sort, dir, onSort }: Props) {
+export function LeaderboardTable({ boardId, columns, rows, currentUserId, isLoading, emptyLabel, sort, dir, onSort }: Props) {
   const tCols = useTranslations("competitions.leaderboard.columns");
   const tColsLong = useTranslations("competitions.leaderboard.columnsLong");
 
@@ -135,7 +138,7 @@ export function LeaderboardTable({ columns, rows, currentUserId, isLoading, empt
                       )}
                     >
                       {isMember ? (
-                        <MemberCell entry={row.original} isMe={isMe} />
+                        <MemberCell entry={row.original} isMe={isMe} boardId={boardId} currentUserId={currentUserId} />
                       ) : meta?.display === "check" ? (
                         <CheckCell value={cell.getValue() as number} />
                       ) : (
@@ -161,12 +164,18 @@ function CheckCell({ value }: { value: number }) {
   );
 }
 
-function MemberCell({ entry, isMe }: { entry: LeaderboardEntry; isMe: boolean }) {
+function MemberCell({ entry, isMe, boardId, currentUserId }: { entry: LeaderboardEntry; isMe: boolean; boardId: number; currentUserId: string }) {
   const t = useTranslations("competitions.leaderboard");
   return (
     <span className="flex min-w-0 flex-col leading-tight">
       <span className="flex min-w-0 items-center gap-1.5">
-        <span className="truncate">{displayName(entry.member.username, entry.member.first_name, entry.member.last_name)}</span>
+        <MemberNameLink
+          boardId={boardId}
+          userId={entry.member.user_id}
+          currentUserId={currentUserId}
+          name={displayName(entry.member.username, entry.member.first_name, entry.member.last_name)}
+          username={entry.member.username}
+        />
         {isMe ? <span className="rounded-md bg-page-accent p-1 text-2xs font-medium uppercase tracking-wide text-white">{t("you")}</span> : null}
       </span>
       <span className="truncate text-xs text-muted-foreground">@{entry.member.username}</span>

--- a/src/features/competitions/components/MemberNameLink.tsx
+++ b/src/features/competitions/components/MemberNameLink.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { hasTournamentStarted } from "@/features/dashboard/lib/tournamentConfig";
+import { Link } from "@/i18n/navigation";
+import { cn } from "@/shared/lib/utils";
+
+type Props = {
+  boardId: number;
+  userId: string;
+  currentUserId: string;
+  /** Display name — rendered here and carried to the picks page. */
+  name: string;
+  /** @-handle — carried to the picks page. */
+  username: string;
+  className?: string;
+};
+
+/**
+ * A board member's name in a leaderboard, linking to their picks page. Only
+ * links after kickoff (picks aren't viewable before) and never the viewer's own
+ * row (they edit at /pickems); otherwise renders plain text.
+ *
+ * The identity travels in the query string so the picks page can title itself
+ * correctly without a roster lookup — that lookup is paginated and misses
+ * members past the first page (especially on large boards), which is what made
+ * the header fall back to "Member".
+ */
+export function MemberNameLink({ boardId, userId, currentUserId, name, username, className }: Props) {
+  const canView = hasTournamentStarted() && userId !== currentUserId;
+  if (!canView) return <span className={cn("truncate", className)}>{name}</span>;
+  const href = `/boards/${boardId}/members/${userId}?n=${encodeURIComponent(name)}&u=${encodeURIComponent(username)}`;
+  return (
+    <Link href={href} className={cn("truncate underline-offset-2 transition-colors hover:text-page-accent hover:underline", className)}>
+      {name}
+    </Link>
+  );
+}

--- a/src/features/dashboard/lib/tournamentConfig.ts
+++ b/src/features/dashboard/lib/tournamentConfig.ts
@@ -2,6 +2,12 @@
 export const TOURNAMENT_START_DATE = new Date("2026-06-11T19:00:00Z");
 export const TOURNAMENT_END_DATE = new Date("2026-07-19T00:00:00Z");
 
+// `now` is a default param so callers can use this during a component render
+// without tripping the no-impure-call-in-render rule (mirrors `awardsLocked`).
+export function hasTournamentStarted(now: number = Date.now()): boolean {
+  return now >= TOURNAMENT_START_DATE.getTime();
+}
+
 export const TOURNAMENT_STATS = {
   totalMatches: 104,
   groupMatches: 72,

--- a/src/features/standings/components/ComparisonLegend.tsx
+++ b/src/features/standings/components/ComparisonLegend.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 
+import { ScoreTally } from "@/shared/components/ScoreTally";
 import { cn } from "@/shared/lib/utils";
 
 import { getAccuracyPillClass } from "../lib/comparison";
@@ -22,12 +23,21 @@ function AccuracyPill({ accuracy, content }: { accuracy: PickAccuracy; content: 
  * top-2 swap. Keeping the two ideas apart was the whole reason we split
  * the legend in two.
  */
-export function ComparisonLegend() {
+type Props = {
+  /** Group-stage earned / possible points. Omitted → the figure is hidden. */
+  summary?: { earned: number; possible: number };
+};
+
+export function ComparisonLegend({ summary }: Props) {
   const t = useTranslations("standings.comparisonLegend");
+  const tScore = useTranslations("standings.score");
 
   return (
     <section aria-label={t("title")} className="flex flex-col gap-4 rounded-xl border border-border bg-card p-4">
-      <p className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("title")}</p>
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("title")}</p>
+        {summary ? <ScoreTally earned={summary.earned} possible={summary.possible} pointsLabel={tScore("pointsLabel")} caption={tScore("earnedPossible")} /> : null}
+      </div>
 
       <div className="flex flex-col gap-2">
         <p className="text-xs font-semibold text-foreground">

--- a/src/features/standings/components/StandingsView.tsx
+++ b/src/features/standings/components/StandingsView.tsx
@@ -10,7 +10,7 @@ import type { UserPickem } from "@/features/pickems/types/pickems.types";
 import { standingsRevealAnimation } from "../animations/standings.animations";
 import { useCompareView } from "../hooks/useCompareView";
 import { useStandings } from "../hooks/useStandings";
-import { buildBestThirdsSet, buildPickIndex } from "../lib/comparison";
+import { buildBestThirdsSet, buildPickIndex, summarizeGroupStage } from "../lib/comparison";
 import { groupAndEnrichStandings } from "../lib/groupStandings";
 import { buildThirdPlaceStandings } from "../lib/thirdPlace";
 import type { StandingRow } from "../types/standings.types";
@@ -44,6 +44,8 @@ export function StandingsView({ initialStandings, initialPickem, pickemFailed, i
   // structures so every row renders with the "not picked" pill.
   const pickIndex = useMemo(() => (comparing ? buildPickIndex(initialPickem) : null), [comparing, initialPickem]);
   const bestThirds = useMemo(() => (comparing ? buildBestThirdsSet(initialPickem) : null), [comparing, initialPickem]);
+  // Aggregate group-stage points for the legend's "earned / possible" figure.
+  const groupSummary = useMemo(() => (comparing ? summarizeGroupStage(groups, pickIndex) : null), [comparing, groups, pickIndex]);
 
   // Pickems is optional — surface a fetch failure once, then fall back to the
   // guest standings. The ref guards against React StrictMode's double-mount.
@@ -87,7 +89,7 @@ export function StandingsView({ initialStandings, initialPickem, pickemFailed, i
 
       {comparing && (
         <div data-reveal>
-          <ComparisonLegend />
+          <ComparisonLegend summary={groupSummary ?? undefined} />
         </div>
       )}
 

--- a/src/features/standings/components/ThirdPlaceCard.tsx
+++ b/src/features/standings/components/ThirdPlaceCard.tsx
@@ -29,34 +29,16 @@ export function ThirdPlaceCard({ standings, bestThirds }: Props) {
   const tAria = useTranslations("standings.columnLabels");
   const showComparison = bestThirds !== null;
   const accuracy = showComparison ? computeThirdPlaceAccuracy(standings.rows, bestThirds) : null;
+  const summary = accuracy && accuracy.total > 0 ? { earned: accuracy.points, possible: accuracy.maxPoints } : undefined;
 
   return (
     <section className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-end justify-between gap-2">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-xl font-bold tracking-tight sm:text-2xl">{t("title")}</h2>
-          <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">{t("description")}</p>
-        </div>
-        {accuracy && accuracy.total > 0 && (
-          <span
-            className={cn(
-              "shrink-0 rounded-full border px-2.5 py-1 text-2xs font-semibold tabular-nums",
-              accuracy.isPerfect ? "border-lime-500/30 bg-lime-500/15 text-lime-700 dark:text-lime-400" : "border-border bg-muted text-muted-foreground"
-            )}
-            aria-label={t("accuracySummary", {
-              correct: accuracy.correct,
-              total: accuracy.total,
-              points: accuracy.points,
-              max: accuracy.maxPoints,
-            })}
-          >
-            {accuracy.isPerfect ? "★ " : ""}
-            {t("accuracyLabel", { correct: accuracy.correct, total: accuracy.total, points: accuracy.points })}
-          </span>
-        )}
+      <div className="flex flex-col gap-1">
+        <h2 className="text-xl font-bold tracking-tight sm:text-2xl">{t("title")}</h2>
+        <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">{t("description")}</p>
       </div>
 
-      {showComparison && <ThirdsLegend />}
+      {showComparison && <ThirdsLegend summary={summary} />}
 
       <article className="overflow-hidden rounded-xl border border-border bg-card" aria-label={t("title")}>
         {/* Same `table-fixed` + width strategy as GroupTable so columns

--- a/src/features/standings/components/ThirdsLegend.tsx
+++ b/src/features/standings/components/ThirdsLegend.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 
+import { ScoreTally } from "@/shared/components/ScoreTally";
 import { cn } from "@/shared/lib/utils";
 
 import { getThirdPlacePillClass } from "../lib/comparison";
@@ -18,12 +19,21 @@ function ThirdsPill({ accuracy, content }: { accuracy: ThirdPlaceAccuracy; conte
  * meaning of the You column is right next to the table that uses it. Mirrors
  * the structure of `ComparisonLegend` for the group tables.
  */
-export function ThirdsLegend() {
+type Props = {
+  /** Best-thirds earned / possible points. Omitted → the figure is hidden. */
+  summary?: { earned: number; possible: number };
+};
+
+export function ThirdsLegend({ summary }: Props) {
   const t = useTranslations("standings.thirdsLegend");
+  const tScore = useTranslations("standings.score");
 
   return (
     <section aria-label={t("title")} className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">
-      <p className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("title")}</p>
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("title")}</p>
+        {summary ? <ScoreTally earned={summary.earned} possible={summary.possible} pointsLabel={tScore("pointsLabel")} caption={tScore("earnedPossible")} /> : null}
+      </div>
       <div className="flex flex-col gap-2">
         <p className="text-xs font-semibold text-foreground">
           {t("youColumn")} <span className="font-normal text-muted-foreground">— {t("youColumnHelp")}</span>

--- a/src/features/standings/lib/comparison.ts
+++ b/src/features/standings/lib/comparison.ts
@@ -2,6 +2,7 @@ import type { UserPickem } from "@/features/pickems/types/pickems.types";
 
 import type {
   GroupComparison,
+  GroupStandings,
   PickAccuracy,
   PickIndex,
   RowComparison,
@@ -73,6 +74,23 @@ export function computeGroupComparison(rows: TeamStandingRow[], groupPicks: Map<
     points += pointsForRow(row, predicted);
   }
   return { correct, total, isPerfect: correct === total, points, maxPoints };
+}
+
+/**
+ * Aggregate points across the whole group stage: earned (sum of each group's
+ * scored points) over possible (sum of every group's max). Unpicked/unlocked
+ * groups contribute 0 earned but their full max to possible, so the figure
+ * always reads against the total achievable — matching the bracket's tally.
+ */
+export function summarizeGroupStage(groups: GroupStandings[], pickIndex: PickIndex | null): { earned: number; possible: number } {
+  let earned = 0;
+  let possible = 0;
+  for (const group of groups) {
+    const comparison = computeGroupComparison(group.rows, pickIndex?.get(group.group_code));
+    earned += comparison.points;
+    possible += comparison.maxPoints;
+  }
+  return { earned, possible };
 }
 
 /** Tailwind classes for the small pill rendering the user's predicted position. */

--- a/src/i18n/messages/boards/en.json
+++ b/src/i18n/messages/boards/en.json
@@ -124,6 +124,8 @@
     "members": {
       "search": "Search members",
       "actions": "Member actions",
+      "viewPicks": "View picks",
+      "viewPicksSubtitle": "Predictions & awards",
       "you": "You",
       "promote": "Make admin",
       "promoteSubtitle": "Let them manage members and competitions",
@@ -167,6 +169,17 @@
         "success": "You left the board"
       }
     }
+  },
+  "member": {
+    "back": "Back to {board}",
+    "subtitle": "Viewing predictions by {name}",
+    "fallbackName": "Member",
+    "tabs": { "pickem": "Pick'em", "awards": "Awards", "matches": "Matches" },
+    "sections": { "groups": "Group standings", "bracket": "Bracket" },
+    "picksUnavailable": "These picks aren't available yet.",
+    "awardsUnavailable": "Awards aren't available yet.",
+    "matchesSoonTitle": "Match predictions coming soon",
+    "matchesSoonHint": "You'll be able to see their pick for every match that's been played, right here."
   },
   "errors": {
     "generic": "Something went wrong"

--- a/src/i18n/messages/boards/es.json
+++ b/src/i18n/messages/boards/es.json
@@ -124,6 +124,8 @@
     "members": {
       "search": "Busca miembros",
       "actions": "Acciones del miembro",
+      "viewPicks": "Ver picks",
+      "viewPicksSubtitle": "Pronósticos y premios",
       "you": "Tú",
       "promote": "Hacer admin",
       "promoteSubtitle": "Podrá gestionar miembros y competencias",
@@ -167,6 +169,17 @@
         "success": "Saliste del board"
       }
     }
+  },
+  "member": {
+    "back": "Volver a {board}",
+    "subtitle": "Viendo los pronósticos de {name}",
+    "fallbackName": "Miembro",
+    "tabs": { "pickem": "Pick'em", "awards": "Premios", "matches": "Partidos" },
+    "sections": { "groups": "Posiciones de grupo", "bracket": "Bracket" },
+    "picksUnavailable": "Estos picks aún no están disponibles.",
+    "awardsUnavailable": "Los premios aún no están disponibles.",
+    "matchesSoonTitle": "Pronósticos de partidos próximamente",
+    "matchesSoonHint": "Aquí podrás ver su pronóstico de cada partido jugado."
   },
   "errors": {
     "generic": "Algo salió mal"

--- a/src/i18n/messages/standings/en.json
+++ b/src/i18n/messages/standings/en.json
@@ -21,6 +21,7 @@
     "wrong0pts": "Wrong (0 pts)",
     "notPicked": "Not picked"
   },
+  "score": { "pointsLabel": "pts", "earnedPossible": "Earned / possible" },
   "thirdsLegend": {
     "title": "How to read · Best thirds",
     "youColumn": "You column",
@@ -63,8 +64,6 @@
     "rank": "#",
     "yourPick": "You",
     "yourPickLabel": "Among your best-thirds picks",
-    "accuracyLabel": "{correct}/{total} · {points} pts",
-    "accuracySummary": "{correct} of {total} best thirds correct, {points} of {max} points earned",
     "advancesLegend": "Top {count} advance to R32"
   }
 }

--- a/src/i18n/messages/standings/es.json
+++ b/src/i18n/messages/standings/es.json
@@ -21,6 +21,7 @@
     "wrong0pts": "Incorrecto (0 pts)",
     "notPicked": "Sin pronosticar"
   },
+  "score": { "pointsLabel": "pts", "earnedPossible": "Obtenidos / posibles" },
   "thirdsLegend": {
     "title": "Cómo leerlo · Mejores terceros",
     "youColumn": "Columna Tú",
@@ -63,8 +64,6 @@
     "rank": "#",
     "yourPick": "Tú",
     "yourPickLabel": "Entre tus pronósticos de terceros",
-    "accuracyLabel": "{correct}/{total} · {points} pts",
-    "accuracySummary": "{correct} de {total} mejores terceros acertados, {points} de {max} puntos",
     "advancesLegend": "Los {count} mejores avanzan a Dieciseisavos"
   }
 }

--- a/src/shared/components/ScoreTally.tsx
+++ b/src/shared/components/ScoreTally.tsx
@@ -1,0 +1,26 @@
+type Props = {
+  earned: number;
+  possible: number;
+  /** Short unit label, e.g. "pts" (already translated). */
+  pointsLabel: string;
+  /** Caption under the figure, e.g. "Earned / possible" (already translated). */
+  caption: string;
+};
+
+/**
+ * Compact "earned / possible" points figure shared by the compare legends
+ * (group standings, best thirds, bracket) so every section reports a score the
+ * same way. Presentational only — callers pass already-translated labels.
+ */
+export function ScoreTally({ earned, possible, pointsLabel, caption }: Props) {
+  return (
+    <div className="flex shrink-0 flex-col items-end leading-none">
+      <span className="flex items-baseline gap-1">
+        <span className="text-xl font-bold tabular-nums text-page-accent">{earned}</span>
+        <span className="text-sm tabular-nums text-muted-foreground">/ {possible}</span>
+        <span className="ml-0.5 text-2xs font-medium uppercase tracking-wider text-muted-foreground">{pointsLabel}</span>
+      </span>
+      <span className="mt-1 text-2xs font-medium uppercase tracking-wider text-muted-foreground">{caption}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Related issue

N/A — continuation of the User Pick'em feature on `WEB-User-Pickem`.

## What changed

**View another board member's predictions.** New board-scoped route `/boards/[boardId]/members/[userId]` showing a member's:
- **Pick'em** — group standings + bracket in **compare mode** (their predictions vs the actual results, with the points they earned). Reuses the existing standings & bracket compare primitives — no duplicated scoring logic; only the pickem source differs (the member's, not the viewer's).
- **Awards** — read-only award cards.
- **Matches** — reserved tab with a "coming soon" placeholder (endpoint not built yet).

**Entry points.** Member names in every board leaderboard / summary table now link to that member's picks page (desktop + mobile), and the Members tab keeps its "View picks" action. Both are gated by kickoff (`hasTournamentStarted`) and never link your own row. The member's identity is carried in the link's query string so the header titles correctly even when the paginated roster lookup misses it (previously fell back to "Member").

**Points everywhere.** A shared `ScoreTally` surfaces earned / possible points on the group-standings, best-thirds and bracket compare legends — on both `/standings` and the member view.

## How to test

1. Sign in and open a board with a competition leaderboard (or the **Summary** tab).
2. After kickoff, click a member's name in any standings table (or **Members** tab → member → **View picks**).
3. Member view: **Pick'em** shows their group/bracket compare with points, **Awards** shows their picks, **Matches** shows the coming-soon placeholder.
4. Confirm your own name isn't a link, and the header shows the correct name (not "Member").
5. On `/standings` in compare mode, the group and best-thirds legends now show earned / possible points.