### PR TITLE
fix: dashboard mobile layout and stats-strip polish

### DIFF
--- a/src/features/dashboard/components/DashboardView.tsx
+++ b/src/features/dashboard/components/DashboardView.tsx
@@ -32,10 +32,13 @@ export function DashboardView({ isLoggedIn, data, currentUserId, lastBoard, admi
   return (
     <div className="relative flex flex-col">
       <section className="container py-6 lg:py-8">
-        <div className="grid gap-7 lg:grid-cols-[minmax(0,1.72fr)_minmax(300px,1fr)] lg:items-stretch">
+        {/* On mobile the two wrappers collapse (`contents`) so every card flows into one
+            ordered column — featured match, then quick actions, then the rest. On lg they
+            become the two grid columns again. */}
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1.72fr)_minmax(300px,1fr)] lg:gap-7 lg:items-stretch">
           {/* Main column — what to do next */}
-          <div className="flex min-w-0 flex-col gap-4">
-            {nextMatch && <FeaturedMatchCard match={nextMatch} isLoggedIn delay={0} />}
+          <div className="contents lg:flex lg:min-w-0 lg:flex-col lg:gap-4">
+            {nextMatch && <FeaturedMatchCard match={nextMatch} isLoggedIn delay={0} className="order-first lg:order-none" />}
             {data?.stats && <StatsStrip pickedChampion={data.picked_champion} stats={data.stats} delay={0.08} />}
             <CardReveal bare delay={0.12} className="opacity-0">
               <SlimBanner stageCode={nextMatch?.stage_code ?? null} isLoggedIn />
@@ -45,8 +48,8 @@ export function DashboardView({ isLoggedIn, data, currentUserId, lastBoard, admi
           </div>
 
           {/* Rail — context and standing (slides in from the right) */}
-          <aside className="flex min-w-0 flex-col gap-4">
-            <QuickActionsCard board={lastBoard} adminBoards={adminBoards} delay={0.1} from="right" />
+          <aside className="contents lg:flex lg:min-w-0 lg:flex-col lg:gap-4">
+            <QuickActionsCard board={lastBoard} adminBoards={adminBoards} delay={0.1} from="right" className="-order-1 lg:order-none" />
             <TitleFavoritesCard favorites={data?.title_favorites ?? []} delay={0.16} from="right" />
             <LeaderboardCard leaderboard={data?.leaderboard ?? null} currentUserId={currentUserId} delay={0.22} from="right" />
           </aside>

--- a/src/features/dashboard/components/FeaturedMatchCard.tsx
+++ b/src/features/dashboard/components/FeaturedMatchCard.tsx
@@ -20,10 +20,11 @@ type Props = {
   match: Match;
   isLoggedIn: boolean;
   delay?: number;
+  className?: string;
 };
 
 // Primary "what to do next" card: the next upcoming match with the user's pick state.
-export function FeaturedMatchCard({ match, isLoggedIn, delay }: Props) {
+export function FeaturedMatchCard({ match, isLoggedIn, delay, className }: Props) {
   const t = useTranslations("dashboard.featured");
   const stageT = useTranslations("schedule.filters.stage");
   const locale = useLocale();
@@ -36,7 +37,10 @@ export function FeaturedMatchCard({ match, isLoggedIn, delay }: Props) {
   const stageLabel = match.stage_code === "group_stage" && match.group_code ? t("stage.group", { group: match.group_code }) : stageT(match.stage_code);
 
   return (
-    <CardReveal delay={delay} className="opacity-0 relative gap-5 border border-page-accent/30 bg-card p-4 shadow-[0_6px_22px_-18px_var(--page-accent)] sm:p-6">
+    <CardReveal
+      delay={delay}
+      className={cn("opacity-0 relative gap-5 border border-page-accent/30 bg-card p-4 shadow-[0_6px_22px_-18px_var(--page-accent)] sm:p-6", className)}
+    >
       {/* Top accent line (clipped by the card's rounded corners) */}
       <span aria-hidden className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-linear-to-r from-page-accent to-page-accent/40" />
 
@@ -55,13 +59,16 @@ export function FeaturedMatchCard({ match, isLoggedIn, delay }: Props) {
       <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 sm:gap-4">
         <TeamColumn team={match.teams.home} locale={locale} align="start" />
 
-        <div data-depth="12" className="flex shrink-0 items-center justify-center px-1">
+        <div data-depth="12" className="flex shrink-0 flex-col items-center justify-center gap-1 px-1">
           {pick ? (
-            <span className="font-heading text-2xl font-bold tabular-nums leading-none text-foreground sm:text-3xl">
-              {pick.home_score}
-              <span className="mx-1 text-muted-foreground/60 sm:mx-1.5">–</span>
-              {pick.away_score}
-            </span>
+            <>
+              <span className="font-heading text-2xl font-bold tabular-nums leading-none text-foreground sm:text-3xl">
+                {pick.home_score}
+                <span className="mx-1 text-muted-foreground/60 sm:mx-1.5">–</span>
+                {pick.away_score}
+              </span>
+              <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">{t("yourPick")}</span>
+            </>
           ) : (
             <span className="font-heading text-lg font-bold leading-none text-muted-foreground/60 sm:text-xl">{t("vs")}</span>
           )}

--- a/src/features/dashboard/components/NewCompetitionDialog.tsx
+++ b/src/features/dashboard/components/NewCompetitionDialog.tsx
@@ -9,7 +9,7 @@ import { Link, useRouter } from "@/i18n/navigation";
 import { Button } from "@/shared/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/shared/components/ui/dialog";
 
-const ROW_CLASS = "-mx-2 flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-muted dark:hover:bg-muted";
+const ROW_CLASS = "-mx-2 flex items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-muted dark:hover:bg-muted";
 
 type Props = {
   // Boards the viewer can create a competition in (admin/owner, non-global).
@@ -39,7 +39,7 @@ export function NewCompetitionDialog({ boards }: Props) {
             <span className="truncate text-sm font-semibold">{t("newCompetition")}</span>
             <span className="truncate text-xs text-muted-foreground">{t("newCompetitionSub")}</span>
           </span>
-          <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+          <ChevronRight className="-mr-1.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
         </button>
       </DialogTrigger>
 
@@ -60,7 +60,7 @@ export function NewCompetitionDialog({ boards }: Props) {
                   <span className="truncate text-sm font-semibold">{board.name}</span>
                   <span className="truncate text-xs capitalize text-muted-foreground">{board.privacy}</span>
                 </span>
-                <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                <ChevronRight className="-mr-1.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
               </button>
             ))}
           </div>

--- a/src/features/dashboard/components/ProgressCard.tsx
+++ b/src/features/dashboard/components/ProgressCard.tsx
@@ -62,44 +62,73 @@ export async function ProgressCard({ state, isLoggedIn, delay }: Props) {
     );
   }
 
+  const ring = (
+    <ProgressRing
+      value={recap ? recap.correct_picks : state.completed}
+      total={recap ? Math.max(recap.scored_picks, 1) : state.total}
+      className={cn("shrink-0", STATUS_RING[state.status])}
+    >
+      <RingCenter state={state} />
+    </ProgressRing>
+  );
+
+  const badge = (
+    <span className={cn("inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-0.5 text-2xs font-medium", STATUS_BADGE[state.status])}>
+      {isLocked && <Lock className="size-2.5" aria-hidden />}
+      {t(`status.${state.status}`)}
+    </span>
+  );
+
+  const heading = (
+    <>
+      <CategoryName icon={Icon} title={t(`${state.id}.title`)} />
+      <p className="text-xs leading-snug text-muted-foreground">{t(`${state.id}.blurb`)}</p>
+    </>
+  );
+
+  const footer = (
+    <div className="flex items-center justify-between gap-2 border-t border-border pt-3">
+      <span className="text-xs font-medium tabular-nums text-muted-foreground">
+        {recap
+          ? recap.scored_picks > 0
+            ? t("recap.correct", { correct: recap.correct_picks, scored: recap.scored_picks })
+            : t("recap.noneScored")
+          : t(`${state.id}.count`, { completed: state.completed, total: state.total })}
+      </span>
+      {state.status === "inProgress" || state.status === "todo" ? (
+        <Button asChild size="sm" className="bg-page-accent text-white hover:bg-page-accent/90">
+          <Link href={state.href}>{t(`cta.${STATUS_CTA[state.status]}`)}</Link>
+        </Button>
+      ) : (
+        <Button asChild variant="outline" size="sm">
+          <Link href={state.href}>{t(`cta.${STATUS_CTA[state.status]}`)}</Link>
+        </Button>
+      )}
+    </div>
+  );
+
   return (
     <CardReveal delay={delay} className="opacity-0 gap-3 bg-card p-4">
-      <div className="flex items-start justify-between">
-        <ProgressRing
-          value={recap ? recap.correct_picks : state.completed}
-          total={recap ? Math.max(recap.scored_picks, 1) : state.total}
-          className={STATUS_RING[state.status]}
-        >
-          <RingCenter state={state} />
-        </ProgressRing>
-        <span className={cn("inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-2xs font-medium", STATUS_BADGE[state.status])}>
-          {isLocked && <Lock className="size-2.5" aria-hidden />}
-          {t(`status.${state.status}`)}
-        </span>
+      {/* Mobile: ring + heading on a row, then a full-width footer (divider spans the card) */}
+      <div className="flex flex-col gap-3 sm:hidden">
+        <div className="flex items-center gap-3">
+          {ring}
+          <div className="flex min-w-0 flex-1 items-start justify-between gap-2">
+            <div className="flex min-w-0 flex-1 flex-col gap-1">{heading}</div>
+            {badge}
+          </div>
+        </div>
+        {footer}
       </div>
 
-      <div className="flex flex-1 flex-col gap-1">
-        <CategoryName icon={Icon} title={t(`${state.id}.title`)} />
-        <p className="text-xs leading-snug text-muted-foreground">{t(`${state.id}.blurb`)}</p>
-      </div>
-
-      <div className="flex items-center justify-between gap-2 border-t border-border pt-3">
-        <span className="text-xs font-medium tabular-nums text-muted-foreground">
-          {recap
-            ? recap.scored_picks > 0
-              ? t("recap.correct", { correct: recap.correct_picks, scored: recap.scored_picks })
-              : t("recap.noneScored")
-            : t(`${state.id}.count`, { completed: state.completed, total: state.total })}
-        </span>
-        {state.status === "inProgress" || state.status === "todo" ? (
-          <Button asChild size="sm" className="bg-page-accent text-white hover:bg-page-accent/90">
-            <Link href={state.href}>{t(`cta.${STATUS_CTA[state.status]}`)}</Link>
-          </Button>
-        ) : (
-          <Button asChild variant="outline" size="sm">
-            <Link href={state.href}>{t(`cta.${STATUS_CTA[state.status]}`)}</Link>
-          </Button>
-        )}
+      {/* Desktop: vertical stack */}
+      <div className="hidden flex-1 flex-col gap-3 sm:flex">
+        <div className="flex items-start justify-between">
+          {ring}
+          {badge}
+        </div>
+        <div className="flex flex-1 flex-col gap-1">{heading}</div>
+        {footer}
       </div>
     </CardReveal>
   );

--- a/src/features/dashboard/components/QuickActionsCard.tsx
+++ b/src/features/dashboard/components/QuickActionsCard.tsx
@@ -15,13 +15,14 @@ type Props = {
   adminBoards: BoardListItem[];
   delay?: number;
   from?: "up" | "left" | "right";
+  className?: string;
 };
 
-export async function QuickActionsCard({ board, adminBoards, delay, from }: Props) {
+export async function QuickActionsCard({ board, adminBoards, delay, from, className }: Props) {
   const t = await getTranslations("dashboard.quickActions");
 
   return (
-    <CardReveal delay={delay} from={from} className="opacity-0 gap-3 bg-card p-4 sm:p-5">
+    <CardReveal delay={delay} from={from} className={cn("opacity-0 gap-3 bg-card p-4 sm:p-5", className)}>
       <h2 className="text-base font-semibold">{t("title")}</h2>
       <div className="flex flex-col">
         <NewCompetitionDialog boards={adminBoards} />
@@ -78,7 +79,7 @@ function ActionRow({ href, label, sub, icon: Icon, iconClass, leading }: ActionR
         <span className="truncate text-sm font-semibold">{label}</span>
         <span className="truncate text-xs text-muted-foreground">{sub}</span>
       </span>
-      <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+      <ChevronRight className="-mr-1.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
     </Link>
   );
 }

--- a/src/features/dashboard/components/StatsStrip.tsx
+++ b/src/features/dashboard/components/StatsStrip.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { getTeamName } from "@/shared/lib/getTeamName";
+import { cn } from "@/shared/lib/utils";
 
 import type { DashboardStats, Team } from "../types/dashboard.types";
 
@@ -14,45 +15,96 @@ type Props = {
   delay?: number;
 };
 
-// Compact "your standing" strip under the featured match: champion pick + both competition ranks.
+// "Your standing" summary under the featured match: champion pick + both competition ranks.
+// Mobile leads with the champion as a headline row and drops the two ranks into a 2-up tile row
+// below it (so the full labels fit); desktop is the flat 3-up strip.
 export async function StatsStrip({ pickedChampion, stats, delay }: Props) {
   const [t, locale] = await Promise.all([getTranslations("dashboard.stats"), getLocale()]);
 
+  const championFlag = pickedChampion ? (
+    <Image src={pickedChampion.flag_url} alt="" width={28} height={20} sizes="28px" className="h-4 w-6 shrink-0 rounded-xs object-cover" />
+  ) : (
+    // No pick yet — a flag-shaped placeholder, matching the schedule's undefined-team treatment.
+    <span className="h-4 w-6 shrink-0 rounded-xs bg-muted" aria-hidden />
+  );
+  const championValue = pickedChampion ? getTeamName(pickedChampion, locale) : t("noChampion");
+
   return (
-    <CardReveal delay={delay} className="opacity-0 grid grid-cols-3 divide-x divide-border bg-card p-0">
-      <StatTile
-        label={t("predictedChampion")}
-        icon={Trophy}
-        iconContent={
-          pickedChampion ? <Image src={pickedChampion.flag_url} alt="" width={28} height={20} sizes="28px" className="h-3.5 w-5.5 rounded-xs object-cover" /> : null
-        }
-        value={pickedChampion ? getTeamName(pickedChampion, locale) : "—"}
-      />
-      <StatTile label={t("pickemRank")} icon={GitBranch} value={`${stats.pickem.points} pts`} detail={`#${stats.pickem.rank}`} />
-      <StatTile label={t("matchRank")} icon={Target} value={`${stats.match.points} pts`} detail={`#${stats.match.rank}`} />
+    <CardReveal delay={delay} className="opacity-0 bg-card p-0">
+      {/* Mobile: champion headline, then the two ranks as tiles */}
+      <div className="sm:hidden">
+        <div className="flex items-center justify-between gap-3 px-4 py-3">
+          <Label icon={Trophy}>{t("predictedChampion")}</Label>
+          <StatValue flag={championFlag} value={championValue} muted={!pickedChampion} />
+        </div>
+        <div className="grid grid-cols-2 border-t border-border">
+          <RankTile className="border-r border-border" icon={GitBranch} label={t("pickemRank")} points={stats.pickem.points} rank={stats.pickem.rank} />
+          <RankTile icon={Target} label={t("matchRank")} points={stats.match.points} rank={stats.match.rank} />
+        </div>
+      </div>
+
+      {/* Desktop: flat 3-up strip */}
+      <div className="hidden divide-x divide-border sm:grid sm:grid-cols-3">
+        <DesktopTile icon={Trophy} label={t("predictedChampion")}>
+          <StatValue flag={championFlag} value={championValue} muted={!pickedChampion} />
+        </DesktopTile>
+        <DesktopTile icon={GitBranch} label={t("pickemRank")}>
+          <StatValue value={`${stats.pickem.points} pts`} detail={`#${stats.pickem.rank}`} />
+        </DesktopTile>
+        <DesktopTile icon={Target} label={t("matchRank")}>
+          <StatValue value={`${stats.match.points} pts`} detail={`#${stats.match.rank}`} />
+        </DesktopTile>
+      </div>
     </CardReveal>
   );
 }
 
-type StatTileProps = {
-  label: string;
-  icon: LucideIcon;
-  iconContent?: React.ReactNode;
-  value: string;
-  detail?: string;
-};
-
-function StatTile({ label, icon: Icon, iconContent, value, detail }: StatTileProps) {
+function Label({ icon: Icon, children }: { icon: LucideIcon; children: React.ReactNode }) {
   return (
-    <div className="flex min-w-0 flex-col gap-1 px-3 py-3 sm:px-4">
-      <span className="flex items-center gap-1.5 text-2xs uppercase tracking-wider text-muted-foreground">
-        <Icon className="size-3 shrink-0" aria-hidden />
-        <span className="truncate">{label}</span>
+    <span className="flex items-center gap-1.5 text-2xs uppercase tracking-wider text-muted-foreground">
+      <Icon className="size-3 shrink-0" aria-hidden />
+      <span className="truncate">{children}</span>
+    </span>
+  );
+}
+
+function StatValue({ flag, value, detail, muted }: { flag?: React.ReactNode; value?: string; detail?: string; muted?: boolean }) {
+  return (
+    <span className={cn("flex min-h-6 min-w-0 gap-1.5", flag ? "items-center" : "items-baseline")}>
+      {flag}
+      {value &&
+        (muted ? (
+          // No pick: a quiet label, sized to match the rank detail (e.g. "#21").
+          <span className="truncate text-xs font-medium text-muted-foreground">{value}</span>
+        ) : (
+          <span className="truncate font-heading text-sm font-bold leading-tight sm:text-base">{value}</span>
+        ))}
+      {detail && <span className="shrink-0 text-xs font-semibold tabular-nums text-muted-foreground">{detail}</span>}
+    </span>
+  );
+}
+
+function DesktopTile({ icon, label, children }: { icon: LucideIcon; label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1 px-4 py-3">
+      <Label icon={icon}>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+// Mobile rank tile: label up top (wraps to 2 lines), points pinned to the bottom so both
+// tiles' values align even when one label wraps and the other doesn't.
+function RankTile({ icon: Icon, label, points, rank, className }: { icon: LucideIcon; label: string; points: number; rank: number; className?: string }) {
+  return (
+    <div className={cn("flex flex-col justify-between gap-2 px-4 py-3", className)}>
+      <span className="flex items-start gap-1.5 text-2xs uppercase leading-tight tracking-wider text-muted-foreground">
+        <Icon className="mt-px size-3 shrink-0" aria-hidden />
+        <span className="line-clamp-2">{label}</span>
       </span>
-      <span className="flex min-w-0 items-baseline gap-1.5">
-        {iconContent}
-        <span className="truncate font-heading text-sm font-bold leading-tight sm:text-base">{value}</span>
-        {detail && <span className="shrink-0 text-xs font-semibold tabular-nums text-muted-foreground">{detail}</span>}
+      <span className="flex items-baseline gap-1.5">
+        <span className="font-heading text-base font-bold leading-tight">{points} pts</span>
+        <span className="text-xs font-semibold tabular-nums text-muted-foreground">#{rank}</span>
       </span>
     </div>
   );

--- a/src/i18n/messages/dashboard/en.json
+++ b/src/i18n/messages/dashboard/en.json
@@ -68,6 +68,7 @@
     "kicker": "Up next",
     "kickoffIn": "Kickoff in <val>{time}</val>",
     "vs": "VS",
+    "yourPick": "Your pick",
     "stage": {
       "group": "Group {group}"
     },
@@ -152,6 +153,7 @@
   },
   "stats": {
     "predictedChampion": "Predicted champion",
+    "noChampion": "Not picked",
     "pickemRank": "Pick'em ranking",
     "matchRank": "Match Picks ranking"
   },

--- a/src/i18n/messages/dashboard/es.json
+++ b/src/i18n/messages/dashboard/es.json
@@ -66,6 +66,7 @@
   },
   "stats": {
     "predictedChampion": "Campeón predicho",
+    "noChampion": "Sin elegir",
     "pickemRank": "Ranking pick'em",
     "matchRank": "Ranking picks de partidos"
   },
@@ -73,6 +74,7 @@
     "kicker": "Próximo partido",
     "kickoffIn": "Inicia en <val>{time}</val>",
     "vs": "VS",
+    "yourPick": "Tu pronóstico",
     "stage": {
       "group": "Grupo {group}"
     },


### PR DESCRIPTION
## Related issue

Closes #99

## What changed

- Reorder the dashboard on mobile so it reads featured match → quick actions → the rest (`DashboardView` collapses its two columns with `display: contents`)
- Rework the stats strip on mobile: champion as a headline row with the two ranks as a 2-up tile row below; desktop keeps the flat 3-up strip
- Show a flag-shaped placeholder + muted "Not picked" when no champion is predicted
- Compact the progress cards on mobile (ring + content on one row, full-width footer divider)
- Add a muted "Your pick" label under the featured match score
- Fix Quick-actions rows: symmetric hover highlight and chevron alignment

## How to test

- [ ] At phone width, dashboard order is featured → quick actions → stats → progress → standings → favorites → leaderboard
- [ ] Stats strip: mobile shows champion headline + two rank tiles; desktop shows the 3-up strip with aligned heights
- [ ] With no champion pick, the champion stat shows a flag placeholder + muted "Not picked"
- [ ] Featured match with a pick shows a muted "Your pick" under the score
- [ ] Quick-actions row hover highlight is inset equally left/right
- [ ] Toggle EN/ES — "Your pick" and "Not picked" are localized