### PR TITLE
fix: handle 200/201 on board join for already-member case

### DIFF
--- a/src/features/boards/api/boards.ts
+++ b/src/features/boards/api/boards.ts
@@ -54,8 +54,10 @@ export async function createBoard(input: CreateBoardInput): Promise<Board> {
   return unwrap(await api.post<Board>("/api/boards", input, { authenticated: true }), "Failed to create board");
 }
 
-export async function joinBoard(input: JoinBoardInput): Promise<{ board_id: number }> {
-  return unwrap(await api.post<{ board_id: number }>("/api/boards/join", input, { authenticated: true }), "Failed to join board");
+export async function joinBoard(input: JoinBoardInput): Promise<{ board_id: number; alreadyMember: boolean }> {
+  const res = await api.post<{ board_id: number }>("/api/boards/join", input, { authenticated: true });
+  const data = unwrap(res, "Failed to join board");
+  return { ...data, alreadyMember: res.status === 200 };
 }
 
 export async function updateBoard(id: number, input: UpdateBoardInput): Promise<void> {

--- a/src/features/boards/components/JoinBoardDialog.tsx
+++ b/src/features/boards/components/JoinBoardDialog.tsx
@@ -51,7 +51,7 @@ export function JoinBoardDialog({ open, onOpenChange }: Props) {
     });
     if (!res) return;
 
-    toast.success(t("success"));
+    toast.success(res.alreadyMember ? t("alreadyMember") : t("success"));
     rememberLastBoard(res.board_id);
     reset();
     onOpenChange(false);

--- a/src/features/boards/components/JoinInviteCard.tsx
+++ b/src/features/boards/components/JoinInviteCard.tsx
@@ -72,7 +72,7 @@ function ValidInvite({ preview, code, isAuthenticated }: { preview: BoardPreview
     if (!res) return;
 
     setJoined(true);
-    toast.success(t("success"));
+    toast.success(res.alreadyMember ? t("alreadyMember") : t("success"));
     rememberLastBoard(res.board_id);
     router.push(`/boards/${res.board_id}`);
     router.refresh();

--- a/src/features/boards/hooks/useBoardMutations.ts
+++ b/src/features/boards/hooks/useBoardMutations.ts
@@ -32,7 +32,7 @@ export function useCreateBoard() {
 }
 
 export function useJoinBoard() {
-  return useMutation<{ board_id: number }, Error, JoinBoardInput>({ mutationFn: joinBoard });
+  return useMutation<{ board_id: number; alreadyMember: boolean }, Error, JoinBoardInput>({ mutationFn: joinBoard });
 }
 
 export function useRenameBoard(id: number) {

--- a/src/i18n/messages/boards/en.json
+++ b/src/i18n/messages/boards/en.json
@@ -62,6 +62,7 @@
     "join": "Join board",
     "cancel": "Not now",
     "success": "Welcome to the board",
+    "alreadyMember": "You're already in this board",
     "codeFooter": "Joining with code",
     "invalidTitle": "Invite not found",
     "invalidDescription": "This invite link is invalid or has expired. Ask for a fresh one.",
@@ -89,6 +90,7 @@
     "cancel": "Cancel",
     "submit": "Join",
     "success": "Welcome to the board",
+    "alreadyMember": "You're already in this board",
     "invalid": "That code didn't work"
   },
   "manage": {

--- a/src/i18n/messages/boards/es.json
+++ b/src/i18n/messages/boards/es.json
@@ -62,6 +62,7 @@
     "join": "Unirme al board",
     "cancel": "Ahora no",
     "success": "Te uniste al board",
+    "alreadyMember": "Ya eres miembro de este board",
     "codeFooter": "Te unes con el código",
     "invalidTitle": "Invitación no encontrada",
     "invalidDescription": "Este enlace de invitación no es válido o expiró. Pide uno nuevo.",
@@ -89,6 +90,7 @@
     "cancel": "Cancelar",
     "submit": "Unirme",
     "success": "Te uniste al board",
+    "alreadyMember": "Ya eres miembro de este board",
     "invalid": "Ese código no funcionó"
   },
   "manage": {

--- a/src/shared/lib/api/client.ts
+++ b/src/shared/lib/api/client.ts
@@ -98,7 +98,7 @@ async function request<T>(endpoint: string, options: RequestOptions = { method: 
       return { success: false, error: { code, message, requestId, fields } };
     }
 
-    return { success: true, data: body.data, pagination: body.pagination };
+    return { success: true, data: body.data, pagination: body.pagination, status: response.status };
   } catch (error) {
     // A request aborted via its signal (e.g. React Query cancelling a superseded
     // or unmounted query) is not a failure — rethrow so the caller treats it as

--- a/src/shared/lib/api/types.ts
+++ b/src/shared/lib/api/types.ts
@@ -3,6 +3,7 @@ export type ApiResponse<T = void> = {
   data?: T;
   pagination?: Pagination;
   error?: ApiError;
+  status?: number;
 };
 
 export type Pagination = {


### PR DESCRIPTION
## Related issue

N/A — follows API change in #109

## What changed

- `POST /boards/join` now returns `200` (already member) or `201` (new join); client handles both as success
- `joinBoard` surfaces `alreadyMember: boolean` derived from the HTTP status code
- Both join surfaces (dialog + invite landing) show distinct toast: "Welcome to the board" vs "You're already in this board"
- `ApiResponse` and `client.ts` now forward the HTTP status on success responses

## How to test

- [ ] Join a board you're not in → `201` → toast "Welcome to the board" → navigated to board
- [ ] Hit the same invite link / enter the same code again → `200` → toast "You're already in this board" → navigated to board
- [ ] Enter a bogus code → error toast (unchanged)
- [ ] Repeat both scenarios in Spanish locale