### PR TITLE
chore: release v1.4.2

### DIFF
--- a/src/features/dashboard/api/dashboard.api.ts
+++ b/src/features/dashboard/api/dashboard.api.ts
@@ -1,18 +1,27 @@
 import { serverApi } from "@/shared/lib/api/server";
 
-import type { DashboardData } from "../types/dashboard.types";
+import { resolveNextMatches } from "../lib/resolveNextMatches";
+import type { DashboardData, Match } from "../types/dashboard.types";
 
 export const DASHBOARD_CACHE_TAG = "dashboard";
 
-// GET /dashboard — consolidated payload: champion, stats, next match, progress,
-// leaderboard, and title favorites. All fields come straight from the API.
+// The wire shape: `next_matches` is the primary array; `next_match` is a single-object
+// fallback. Both optional so the resolver can pick whichever the API sends.
+type DashboardApiResponse = Omit<DashboardData, "next_matches"> & {
+  next_matches?: Match[] | null;
+  next_match?: Match | null;
+};
+
+// GET /dashboard — consolidated payload: champion, stats, next match(es), progress,
+// leaderboard, and title favorites. `next_matches` is resolved to an array so the
+// dashboard works whether the API sends the array or just the fallback object.
 export async function getDashboard(isAuthenticated: boolean): Promise<DashboardData | null> {
-  const response = await serverApi.get<DashboardData>("/api/dashboard", {
+  const response = await serverApi.get<DashboardApiResponse>("/api/dashboard", {
     authenticated: isAuthenticated,
     next: { revalidate: 60, tags: [DASHBOARD_CACHE_TAG] },
   });
 
   if (!response.success || !response.data) return null;
 
-  return response.data;
+  return { ...response.data, next_matches: resolveNextMatches(response.data) };
 }

--- a/src/features/dashboard/components/DashboardView.tsx
+++ b/src/features/dashboard/components/DashboardView.tsx
@@ -4,7 +4,7 @@ import type { StandingRow } from "@/features/standings/types/standings.types";
 import type { DashboardData } from "../types/dashboard.types";
 
 import { CardReveal } from "./CardReveal";
-import { FeaturedMatchCard } from "./FeaturedMatchCard";
+import { FeaturedMatchesSection } from "./FeaturedMatchesSection";
 import { GroupStandingsCard } from "./GroupStandingsCard";
 import { GuestLanding } from "./GuestLanding";
 import { LeaderboardCard } from "./LeaderboardCard";
@@ -27,7 +27,9 @@ export function DashboardView({ isLoggedIn, data, currentUserId, lastBoard, admi
   // Guests get the dedicated marketing landing; members get the dashboard.
   if (!isLoggedIn) return <GuestLanding data={data} />;
 
-  const nextMatch = data?.next_match ?? null;
+  const nextMatches = data?.next_matches ?? [];
+  // Cards that key off a single match (stage hint, group standings) follow the first.
+  const primaryMatch = nextMatches[0] ?? null;
 
   return (
     <div className="relative flex flex-col">
@@ -38,13 +40,13 @@ export function DashboardView({ isLoggedIn, data, currentUserId, lastBoard, admi
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1.72fr)_minmax(300px,1fr)] lg:gap-7 lg:items-stretch">
           {/* Main column — what to do next */}
           <div className="contents lg:flex lg:min-w-0 lg:flex-col lg:gap-4">
-            {nextMatch && <FeaturedMatchCard match={nextMatch} isLoggedIn delay={0} className="order-first lg:order-none" />}
+            <FeaturedMatchesSection matches={nextMatches} isLoggedIn className="order-first lg:order-none" />
             {data?.stats && <StatsStrip pickedChampion={data.picked_champion} stats={data.stats} delay={0.08} />}
             <CardReveal bare delay={0.12} className="opacity-0">
-              <SlimBanner stageCode={nextMatch?.stage_code ?? null} isLoggedIn />
+              <SlimBanner stageCode={primaryMatch?.stage_code ?? null} isLoggedIn />
             </CardReveal>
             <ProgressCardsSection progress={data?.progress ?? null} recap={data?.recap ?? null} isLoggedIn delay={0.16} />
-            <GroupStandingsCard rows={standings} preferredGroup={nextMatch?.group_code ?? data?.picked_champion?.group_code ?? null} delay={0.24} />
+            <GroupStandingsCard rows={standings} preferredGroup={primaryMatch?.group_code ?? data?.picked_champion?.group_code ?? null} delay={0.24} />
           </div>
 
           {/* Rail — context and standing (slides in from the right) */}

--- a/src/features/dashboard/components/FeaturedMatchCard.tsx
+++ b/src/features/dashboard/components/FeaturedMatchCard.tsx
@@ -21,10 +21,13 @@ type Props = {
   isLoggedIn: boolean;
   delay?: number;
   className?: string;
+  // Set when two cards sit side by side (simultaneous matches): the card is ~half
+  // width, so the team names stay capped instead of scaling up to the full-width size.
+  compact?: boolean;
 };
 
 // Primary "what to do next" card: the next upcoming match with the user's pick state.
-export function FeaturedMatchCard({ match, isLoggedIn, delay, className }: Props) {
+export function FeaturedMatchCard({ match, isLoggedIn, delay, className, compact = false }: Props) {
   const t = useTranslations("dashboard.featured");
   const stageT = useTranslations("schedule.filters.stage");
   const locale = useLocale();
@@ -57,7 +60,7 @@ export function FeaturedMatchCard({ match, isLoggedIn, delay, className }: Props
 
       {/* Teams row — center holds only the score/VS so names get the full column width */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 sm:gap-4">
-        <TeamColumn team={match.teams.home} locale={locale} align="start" />
+        <TeamColumn team={match.teams.home} locale={locale} align="start" compact={compact} />
 
         <div data-depth="12" className="flex shrink-0 flex-col items-center justify-center gap-1 px-1">
           {pick ? (
@@ -74,7 +77,7 @@ export function FeaturedMatchCard({ match, isLoggedIn, delay, className }: Props
           )}
         </div>
 
-        <TeamColumn team={match.teams.away} locale={locale} align="end" />
+        <TeamColumn team={match.teams.away} locale={locale} align="end" compact={compact} />
       </div>
 
       {/* Meta row — countdown + venue, full width below the teams */}
@@ -110,8 +113,11 @@ export function FeaturedMatchCard({ match, isLoggedIn, delay, className }: Props
   );
 }
 
-function TeamColumn({ team, locale, align }: { team: Team | null; locale: string; align: "start" | "end" }) {
+function TeamColumn({ team, locale, align, compact }: { team: Team | null; locale: string; align: "start" | "end"; compact: boolean }) {
   const alignClass = align === "start" ? "items-start text-left" : "items-end text-right";
+  // Full-width cards let names grow to text-2xl; a side-by-side (compact) card is too
+  // narrow for that, so cap names at text-lg to keep them clear of the centered score.
+  const nameClass = compact ? "text-base sm:text-lg" : "text-base sm:text-lg lg:text-xl xl:text-2xl";
   return (
     <div className={cn("flex min-w-0 flex-col gap-2.5", alignClass)}>
       {team ? (
@@ -119,7 +125,7 @@ function TeamColumn({ team, locale, align }: { team: Team | null; locale: string
       ) : (
         <div className="h-9 w-13 rounded-xs bg-muted sm:h-10 sm:w-14" />
       )}
-      <span className="max-w-full truncate text-base font-bold tracking-tight sm:text-lg lg:text-xl xl:text-2xl">{team ? getTeamName(team, locale) : "TBD"}</span>
+      <span className={cn("max-w-full truncate font-bold tracking-tight", nameClass)}>{team ? getTeamName(team, locale) : "TBD"}</span>
     </div>
   );
 }

--- a/src/features/dashboard/components/FeaturedMatchesSection.tsx
+++ b/src/features/dashboard/components/FeaturedMatchesSection.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { cn } from "@/shared/lib/utils";
+
+import type { Match } from "../types/dashboard.types";
+
+import { FeaturedMatchCard } from "./FeaturedMatchCard";
+
+type Props = {
+  // Upcoming match(es) sharing the earliest kickoff — usually one, occasionally a
+  // pair of simultaneous group-stage finales.
+  matches: Match[];
+  isLoggedIn: boolean;
+  className?: string;
+};
+
+// "What to do next" — one featured card, or a card per simultaneous match. A single
+// match keeps the full-width hero treatment; two or more split into a responsive grid
+// (stacked until xl, two columns beyond it) so every actionable match stays visible and
+// neither card gets cramped at the narrower lg dashboard column width. With an odd count
+// (rare: 3+ simultaneous matches) the trailing card spans the full row instead of sitting
+// alone at half width.
+export function FeaturedMatchesSection({ matches, isLoggedIn, className }: Props) {
+  if (matches.length === 0) return null;
+
+  if (matches.length === 1) {
+    return <FeaturedMatchCard match={matches[0]} isLoggedIn={isLoggedIn} delay={0} className={className} />;
+  }
+
+  return (
+    <div className={cn("grid grid-cols-1 gap-4 xl:grid-cols-2 [&>*:last-child:nth-child(odd)]:xl:col-span-2", className)}>
+      {matches.map((match, index) => (
+        <FeaturedMatchCard key={match.id} match={match} isLoggedIn={isLoggedIn} delay={index * 0.06} className="h-full" compact />
+      ))}
+    </div>
+  );
+}

--- a/src/features/dashboard/components/GroupStandingsCard.tsx
+++ b/src/features/dashboard/components/GroupStandingsCard.tsx
@@ -47,14 +47,16 @@ export function GroupStandingsCard({ rows, preferredGroup, delay }: Props) {
   const safeIndex = ((index % groups.length) + groups.length) % groups.length;
   const group = groups[safeIndex];
   const cycle = (step: number) => setIndex((i) => i + step);
+  // Header leads the card into view by one stagger step.
+  const baseDelay = delay ?? 0;
 
   return (
     <section className="flex flex-1 flex-col gap-3">
-      <div className="flex flex-col gap-0.5">
+      <CardReveal bare delay={baseDelay} className="opacity-0 flex flex-col gap-0.5">
         <h2 className="text-base font-semibold">{tDash("heading")}</h2>
         <p className="text-xs text-muted-foreground">{tDash("subtitle")}</p>
-      </div>
-      <CardReveal bare delay={delay} className="opacity-0 flex flex-1 flex-col overflow-hidden rounded-xl border border-border bg-card shadow-xs">
+      </CardReveal>
+      <CardReveal bare delay={baseDelay + 0.06} className="opacity-0 flex flex-1 flex-col overflow-hidden rounded-xl border border-border bg-card shadow-xs">
         <div style={GREEN_ACCENT} className="flex flex-1 flex-col">
           <header className="flex items-center justify-between gap-3 px-4 pt-3 pb-2">
             <div className="flex items-center gap-2">

--- a/src/features/dashboard/components/GuestLanding.tsx
+++ b/src/features/dashboard/components/GuestLanding.tsx
@@ -22,7 +22,8 @@ type Props = {
 export async function GuestLanding({ data }: Props) {
   const [t, tDemo] = await Promise.all([getTranslations("dashboard.landing"), getTranslations("dashboard.landing.demo")]);
   const favorites = data?.title_favorites ?? [];
-  const nextMatch = data?.next_match ?? null;
+  // The marketing hero showcases a single match even when two kick off together.
+  const nextMatch = data?.next_matches?.[0] ?? null;
 
   return (
     <div className="container flex flex-col gap-10 py-6 lg:gap-12 lg:py-8">

--- a/src/features/dashboard/components/ProgressCardsSection.tsx
+++ b/src/features/dashboard/components/ProgressCardsSection.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server";
 import { computeProgressCardStates } from "../lib/progressCardState";
 import type { DashboardProgress, DashboardRecap } from "../types/dashboard.types";
 
+import { CardReveal } from "./CardReveal";
 import { ProgressCard } from "./ProgressCard";
 
 type Props = {
@@ -29,13 +30,13 @@ export async function ProgressCardsSection({ progress, recap, isLoggedIn, delay 
 
   return (
     <section className="flex flex-col gap-3">
-      <div className="flex flex-col gap-0.5">
+      <CardReveal bare delay={delay} className="opacity-0 flex flex-col gap-0.5">
         <h2 className="text-base font-semibold">{isLoggedIn ? t("title") : t("guestTitle")}</h2>
         <p className="text-xs text-muted-foreground">{isLoggedIn ? t("subtitle") : t("guestSubtitle")}</p>
-      </div>
+      </CardReveal>
       <div className="grid gap-3 sm:grid-cols-3">
         {states.map((state, index) => (
-          <ProgressCard key={state.id} state={state} isLoggedIn={isLoggedIn} delay={delay + index * 0.06} />
+          <ProgressCard key={state.id} state={state} isLoggedIn={isLoggedIn} delay={delay + 0.06 + index * 0.06} />
         ))}
       </div>
     </section>

--- a/src/features/dashboard/lib/resolveNextMatches.ts
+++ b/src/features/dashboard/lib/resolveNextMatches.ts
@@ -1,0 +1,16 @@
+import type { Match } from "../types/dashboard.types";
+
+type NextMatchSource = {
+  // Primary field: the array of simultaneous upcoming matches.
+  next_matches?: Match[] | null;
+  // Fallback (older API / safety net): a single upcoming match.
+  next_match?: Match | null;
+};
+
+// Resolve the dashboard's upcoming matches to a Match[]. The `next_matches` array is
+// authoritative when present (even if empty); `next_match` is only used as a fallback
+// when the array is absent.
+export function resolveNextMatches(source: NextMatchSource): Match[] {
+  if (Array.isArray(source.next_matches)) return source.next_matches;
+  return source.next_match ? [source.next_match] : [];
+}

--- a/src/features/dashboard/types/dashboard.types.ts
+++ b/src/features/dashboard/types/dashboard.types.ts
@@ -88,7 +88,11 @@ export type DashboardRecap = {
 export type DashboardData = {
   picked_champion: Team | null;
   stats: DashboardStats;
-  next_match: Match | null;
+  // The upcoming match(es) sharing the earliest kickoff — usually one, but two (or
+  // rarely more) can kick off simultaneously. Resolved at the fetch boundary from the
+  // API's `next_matches` array (primary) or `next_match` object (fallback); empty when
+  // nothing is upcoming.
+  next_matches: Match[];
   progress: DashboardProgress;
   leaderboard: DashboardLeaderboard;
   title_favorites?: TitleFavorite[];

--- a/src/features/schedule/components/GoToTodayButton.tsx
+++ b/src/features/schedule/components/GoToTodayButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { CalendarDays } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { cn } from "@/shared/lib/utils";
+
+type Props = {
+  onPress: () => void;
+  className?: string;
+};
+
+// "Go to today" — scrolls the schedule to the current day's matches. Styled as a solid
+// page-accent CTA so it stands out against the neutral filter chips, and shares the
+// scroll-into-view behaviour of the pending-picks CTA.
+export function GoToTodayButton({ onPress, className }: Props) {
+  const t = useTranslations("schedule");
+
+  return (
+    <button
+      type="button"
+      onClick={onPress}
+      className={cn(
+        "inline-flex h-9 cursor-pointer items-center gap-2 rounded-lg bg-page-accent-strong px-4 text-sm font-semibold text-white shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-page-accent-soft",
+        className
+      )}
+    >
+      <CalendarDays className="size-4 shrink-0" aria-hidden />
+      {t("goToToday")}
+    </button>
+  );
+}

--- a/src/features/schedule/components/MatchCard.tsx
+++ b/src/features/schedule/components/MatchCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { MapPin, MoveRight } from "lucide-react";
+import { MapPin, MoveRight, Timer } from "lucide-react";
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
@@ -15,6 +15,7 @@ import { cn } from "@/shared/lib/utils";
 
 import { useUpdatePick } from "../hooks/useUpdatePick";
 import { computeMatchUiState, type MatchUiState } from "../lib/computeMatchUiState";
+import { useScoringInfoStore } from "../store/scoringInfo.store";
 import type { Match, Team, UserScorePick } from "../types/schedule.types";
 
 import { KickoffCountdown } from "./KickoffCountdown";
@@ -41,24 +42,32 @@ export function MatchCard({ match, isAuthed, autoEdit = false }: Props) {
 
   const hasTeams = match.teams.home != null && match.teams.away != null;
   const canEdit = isAuthed && !uiState.isLocked && hasTeams;
+  // Only knockout matches (R32 onward) can go to extra time, so the 120' scoring
+  // disclaimer + first-pick modal apply there — group-stage matches always end at 90'.
+  const usesExtraTime = match.stage_code !== "group_stage";
 
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<UserScorePick>(() => match.user_score_pick ?? { home_score: 0, away_score: 0 });
   const updatePick = useUpdatePick();
+  const requestPick = useScoringInfoStore((s) => s.requestPick);
+
+  // Open the picker (first time, gated behind the one-time scoring disclaimer).
+  const openPicker = () => {
+    setDraft(match.user_score_pick ?? { home_score: 0, away_score: 0 });
+    setEditing(true);
+  };
+  // Knockout matches show the one-time scoring modal first; group-stage picks open straight away.
+  const startEdit = () => (usesExtraTime ? requestPick(openPicker) : openPicker());
 
   // Open the picker once when deep-linked to this match and it's still pickable.
   const autoOpened = useRef(false);
   useEffect(() => {
     if (autoEdit && canEdit && !autoOpened.current) {
       autoOpened.current = true;
-      setEditing(true);
+      startEdit();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoEdit, canEdit]);
-
-  const startEdit = () => {
-    setDraft(match.user_score_pick ?? { home_score: 0, away_score: 0 });
-    setEditing(true);
-  };
 
   const cancelEdit = () => setEditing(false);
   const save = () =>
@@ -91,6 +100,15 @@ export function MatchCard({ match, isAuthed, autoEdit = false }: Props) {
         />
         <TeamColumn team={match.teams.away} side="away" locale={locale} dim={editing} />
       </div>
+
+      {/* Knockout only (extra time can't happen in the group stage). Rendered in both
+          view and edit modes so the card height stays identical when the picker opens. */}
+      {usesExtraTime && (
+        <p className="-mt-1 flex items-center justify-center gap-1.5 text-2xs text-muted-foreground">
+          <Timer className="size-3 shrink-0" aria-hidden />
+          {t("extraTimeNote", { full: 120 })}
+        </p>
+      )}
 
       <footer className="relative -mx-4 pt-4 flex min-h-9 items-center justify-between gap-3 border-t border-border px-4 text-xs text-muted-foreground">
         <span className="inline-flex min-w-0 max-w-[55%] items-center gap-1.5 sm:max-w-none">

--- a/src/features/schedule/components/ScheduleFilters.tsx
+++ b/src/features/schedule/components/ScheduleFilters.tsx
@@ -12,15 +12,18 @@ import { activeFilterCount } from "../lib/filterMatches";
 import { DEFAULT_FILTERS, type ScheduleFilters as Filters, type Team } from "../types/schedule.types";
 
 import { FilterControls } from "./FilterControls";
+import { GoToTodayButton } from "./GoToTodayButton";
 
 type Props = {
   filters: Filters;
   onChange: (next: Filters) => void;
   teams: Team[];
   tabs?: ReactNode;
+  // Scroll to today's matches; omitted when there are none today (button hidden).
+  onGoToToday?: () => void;
 };
 
-export function ScheduleFilters({ filters, onChange, teams, tabs }: Props) {
+export function ScheduleFilters({ filters, onChange, teams, tabs, onGoToToday }: Props) {
   const t = useTranslations("schedule.filters");
   const locale = useLocale();
   const count = activeFilterCount(filters);
@@ -30,6 +33,9 @@ export function ScheduleFilters({ filters, onChange, teams, tabs }: Props) {
     <div className="sticky top-16 z-20 bg-background">
       <div className="container">
         <div className="border-b border-border py-2">
+          {/* Mobile: "go to today" sits above the filter trigger row. */}
+          {onGoToToday && <GoToTodayButton onPress={onGoToToday} className="mb-2 w-full justify-center lg:hidden" />}
+
           <div className="hidden min-w-0 flex-wrap items-center gap-2 lg:flex">
             <FilterControls filters={filters} onChange={onChange} teams={teams} locale={locale} variant="chip" className="flex flex-wrap items-center gap-2" />
             {count > 0 && (
@@ -38,6 +44,8 @@ export function ScheduleFilters({ filters, onChange, teams, tabs }: Props) {
                 {t("reset")}
               </Button>
             )}
+            {/* Desktop: aligned to the right edge of the filter bar. */}
+            {onGoToToday && <GoToTodayButton onPress={onGoToToday} className="ml-auto" />}
           </div>
 
           <MobileFilters filters={filters} onChange={onChange} teams={teams} locale={locale} count={count} />

--- a/src/features/schedule/components/ScheduleView.tsx
+++ b/src/features/schedule/components/ScheduleView.tsx
@@ -8,6 +8,7 @@ import { useScheduleFilters } from "../hooks/useScheduleFilters";
 import { collectTeams } from "../lib/collectTeams";
 import { computePickStats } from "../lib/computePickStats";
 import { filterMatches } from "../lib/filterMatches";
+import { findTodayMatchId } from "../lib/findTodayMatchId";
 import { groupMatchesByLocalDate } from "../lib/groupByDate";
 import { scrollMatchIntoView } from "../lib/scrollMatchIntoView";
 import { DEFAULT_FILTERS, type Match, type PickFilter } from "../types/schedule.types";
@@ -17,6 +18,7 @@ import { PendingPicksCta } from "./PendingPicksCta";
 import { PickProgressPanel } from "./PickProgressPanel";
 import { PickStatusTabs } from "./PickStatusTabs";
 import { ScheduleFilters } from "./ScheduleFilters";
+import { ScoringInfoDialog } from "./ScoringInfoDialog";
 import { SignedOutCta } from "./SignedOutCta";
 import { UpToDateCta } from "./UpToDateCta";
 
@@ -71,6 +73,9 @@ export function ScheduleView({ initialMatches, anchorMatchId, isAuthed, deepLink
   const tabStats = useMemo(() => computePickStats(filteredByChips), [filteredByChips]);
   const counts = { all: filteredByChips.length, pending: tabStats.pendingAll, picked: tabStats.picked };
 
+  // First match of the user's local "today" — null on rest days, which hides the button.
+  const todayMatchId = useMemo(() => findTodayMatchId(matches), [matches]);
+
   const onPickChange = (next: PickFilter) => setFilters({ ...filters, pick: next });
 
   const showPendingCta = isAuthed && overallStats.pendingAll > 0 && anchorMatchId !== null;
@@ -89,6 +94,7 @@ export function ScheduleView({ initialMatches, anchorMatchId, isAuthed, deepLink
         onChange={setFilters}
         teams={visibleTeams}
         tabs={isAuthed ? <PickStatusTabs value={filters.pick} onChange={onPickChange} counts={counts} /> : undefined}
+        onGoToToday={todayMatchId != null ? () => scrollMatchIntoView(todayMatchId) : undefined}
       />
 
       <div className="container flex flex-col gap-6 py-6">
@@ -98,6 +104,8 @@ export function ScheduleView({ initialMatches, anchorMatchId, isAuthed, deepLink
           groups.map((g) => <MatchDateGroup key={g.key} group={g} isAuthed={isAuthed} autoEditMatchId={autoEditMatchId} />)
         )}
       </div>
+
+      {isAuthed && <ScoringInfoDialog />}
     </div>
   );
 }

--- a/src/features/schedule/components/ScoringInfoDialog.tsx
+++ b/src/features/schedule/components/ScoringInfoDialog.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Timer } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/shared/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
+import { Drawer, DrawerClose, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle } from "@/shared/components/ui/drawer";
+import { useIsMobile } from "@/shared/hooks/useMediaQuery";
+
+import { useScoringInfoStore } from "../store/scoringInfo.store";
+
+// One-time disclaimer shown on the first pick: match-score picks settle on the full
+// result after extra time (120'), unlike sportsbooks that close at 90'. Rendered once
+// by ScheduleView; closing (any way) marks it seen and continues to the card's picker.
+export function ScoringInfoDialog() {
+  const t = useTranslations("schedule.scoringInfo");
+  const isMobile = useIsMobile();
+  const open = useScoringInfoStore((s) => s.open);
+  const acknowledge = useScoringInfoStore((s) => s.acknowledge);
+
+  const onOpenChange = (next: boolean) => {
+    if (!next) acknowledge();
+  };
+
+  const icon = (
+    <span className="flex size-11 items-center justify-center rounded-lg bg-page-accent-soft text-page-accent-strong">
+      <Timer className="size-5" aria-hidden />
+    </span>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent>
+          <DrawerHeader className="items-center gap-3 text-center">
+            {icon}
+            <DrawerTitle className="font-heading text-lg font-semibold">{t("title")}</DrawerTitle>
+            <DrawerDescription className="text-sm text-muted-foreground">{t("body", { regular: 90, full: 120 })}</DrawerDescription>
+          </DrawerHeader>
+          <DrawerFooter>
+            <DrawerClose asChild>
+              <Button className="h-11 w-full bg-page-accent text-background hover:bg-page-accent-strong">{t("cta")}</Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="items-center gap-3 text-center sm:text-center">
+          {icon}
+          <DialogTitle className="font-heading text-lg font-semibold">{t("title")}</DialogTitle>
+          <DialogDescription className="text-sm text-muted-foreground">{t("body", { regular: 90, full: 120 })}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button className="h-11 w-full bg-page-accent text-background hover:bg-page-accent-strong">{t("cta")}</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/schedule/lib/findTodayMatchId.ts
+++ b/src/features/schedule/lib/findTodayMatchId.ts
@@ -1,0 +1,12 @@
+import type { Match } from "../types/schedule.types";
+
+import { localDateKey } from "./groupByDate";
+
+// Id of the first match kicking off on the user's local "today", or null when there
+// are none. Powers the "go to today" scroll, mirroring findAnchorMatchId but anchored
+// to the current day rather than the next unpicked match.
+export function findTodayMatchId(matches: Match[], now: Date = new Date()): number | null {
+  const todayKey = localDateKey(now);
+  const match = matches.find((m) => localDateKey(new Date(m.kickoff_at)) === todayKey);
+  return match?.id ?? null;
+}

--- a/src/features/schedule/lib/groupByDate.ts
+++ b/src/features/schedule/lib/groupByDate.ts
@@ -27,7 +27,9 @@ export function groupMatchesByLocalDate(matches: Match[]): MatchDateGroup[] {
   return Array.from(groups.values());
 }
 
-function localDateKey(d: Date): string {
+// YYYY-MM-DD in the user's local timezone — the bucket key used for grouping and for
+// matching "today".
+export function localDateKey(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");

--- a/src/features/schedule/lib/scoringInfoStorage.ts
+++ b/src/features/schedule/lib/scoringInfoStorage.ts
@@ -1,0 +1,22 @@
+// Whether the "scores count extra time" disclaimer has been shown. Persisted so the
+// modal only interrupts the first pick; mirrors the pickems draft-storage guards
+// (SSR-safe, swallows private-mode / quota errors).
+const KEY = "wcp.schedule.scoringInfoSeen.v1";
+
+export function hasSeenScoringInfo(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function markScoringInfoSeen(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(KEY, "1");
+  } catch {
+    // ignore — storage may be unavailable (private mode, quota, etc.)
+  }
+}

--- a/src/features/schedule/store/scoringInfo.store.ts
+++ b/src/features/schedule/store/scoringInfo.store.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+import { hasSeenScoringInfo, markScoringInfoSeen } from "../lib/scoringInfoStorage";
+
+type ScoringInfoState = {
+  open: boolean;
+  // The pick action to run once the disclaimer is dismissed (open the card's picker).
+  pendingProceed: (() => void) | null;
+  // Gate a pick behind the one-time disclaimer: first time shows the modal, then runs
+  // `proceed`; afterwards `proceed` runs immediately with no interruption.
+  requestPick: (proceed: () => void) => void;
+  // Acknowledge (any close): remember it was seen, then continue the deferred pick.
+  acknowledge: () => void;
+};
+
+export const useScoringInfoStore = create<ScoringInfoState>((set, get) => ({
+  open: false,
+  pendingProceed: null,
+  requestPick: (proceed) => {
+    if (hasSeenScoringInfo()) {
+      proceed();
+      return;
+    }
+    set({ open: true, pendingProceed: proceed });
+  },
+  acknowledge: () => {
+    markScoringInfoSeen();
+    const { pendingProceed } = get();
+    set({ open: false, pendingProceed: null });
+    pendingProceed?.();
+  },
+}));

--- a/src/i18n/messages/schedule/en.json
+++ b/src/i18n/messages/schedule/en.json
@@ -1,5 +1,6 @@
 {
   "title": "Schedule",
+  "goToToday": "Go to today",
   "filters": {
     "openButton": "Filters",
     "title": "Filters",
@@ -41,7 +42,13 @@
     "tapToPick": "Tap to pick",
     "closesIn": "Closes in {time}",
     "save": "Save",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "extraTimeNote": "Scored after extra time ({full} min)"
+  },
+  "scoringInfo": {
+    "title": "Knockout picks count extra time",
+    "body": "If a knockout match goes to extra time, your pick is judged on the {full}-minute result — not {regular} like most betting sites. Penalty shootouts don’t affect your pick; they only decide who advances.",
+    "cta": "Got it"
   },
   "matchCount": "{count, plural, one {# match} other {# matches}}",
   "badge": {

--- a/src/i18n/messages/schedule/es.json
+++ b/src/i18n/messages/schedule/es.json
@@ -1,5 +1,6 @@
 {
   "title": "Calendario",
+  "goToToday": "Ir a hoy",
   "filters": {
     "openButton": "Filtros",
     "title": "Filtros",
@@ -41,7 +42,13 @@
     "tapToPick": "Haz tu pick",
     "closesIn": "Cierra en {time}",
     "save": "Guardar",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "extraTimeNote": "Cuenta tras la prórroga ({full} min)"
+  },
+  "scoringInfo": {
+    "title": "En eliminatorias cuenta la prórroga",
+    "body": "Si un partido de eliminatorias va a prórroga, tu pick se evalúa con el resultado a los {full} minutos, no a los {regular} como en la mayoría de casas de apuestas. Las tandas de penales no afectan tu pick; solo definen quién avanza.",
+    "cta": "Entendido"
   },
   "matchCount": "{count, plural, one {# partido} other {# partidos}}",
   "badge": {


### PR DESCRIPTION
## Release v1.4.2

Patch release with a dashboard improvement for concurrent match display.

### Highlights
- **Dashboard:** simultaneous next matches now render as multiple cards instead of a single collapsed entry, giving users a clearer view when several games kick off at the same time (#112)