### PR TITLE
chore: release v1.5.0

### DIFF
--- a/src/app/[locale]/boards/[boardId]/competitions/[competitionId]/members/[userId]/loading.tsx
+++ b/src/app/[locale]/boards/[boardId]/competitions/[competitionId]/members/[userId]/loading.tsx
@@ -1,0 +1,5 @@
+import { MemberPickemSkeleton } from "@/features/competitions/components/pickemReveal/MemberPickemSkeleton";
+
+export default function MemberPickemLoading() {
+  return <MemberPickemSkeleton />;
+}

--- a/src/app/[locale]/boards/[boardId]/competitions/[competitionId]/members/[userId]/page.tsx
+++ b/src/app/[locale]/boards/[boardId]/competitions/[competitionId]/members/[userId]/page.tsx
@@ -1,0 +1,98 @@
+import { notFound } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
+import { BOARDS_LIST_TAG } from "@/features/boards/api/boards";
+import type { BoardListItem } from "@/features/boards/types/boards.types";
+import { boardLeaderboardsTag, leaderboardTag } from "@/features/competitions/api/competitions";
+import { memberPickemTag } from "@/features/competitions/api/memberPickem";
+import { MemberPickemView } from "@/features/competitions/components/pickemReveal/MemberPickemView";
+import type { LeaderboardEntry, LeaderboardMember, PickemScore } from "@/features/competitions/types/competitions.types";
+import type { UserPickem } from "@/features/pickems/types/pickems.types";
+import { MATCHES_CACHE_TAG } from "@/features/schedule/api/matches";
+import type { Match } from "@/features/schedule/types/schedule.types";
+import { STANDINGS_CACHE_TAG } from "@/features/standings/api/standings";
+import type { StandingRow } from "@/features/standings/types/standings.types";
+import { redirect } from "@/i18n/navigation";
+import { getCurrentUser } from "@/lib/auth";
+import { serverApi } from "@/shared/lib/api/server";
+
+type Props = {
+  params: Promise<{ boardId: string; competitionId: string; userId: string }>;
+  // `n` (display name) + `u` (@handle) carried by the leaderboard link so the
+  // header titles itself correctly even when the leaderboard lookup misses.
+  searchParams: Promise<{ n?: string; u?: string }>;
+};
+
+export default async function MemberPickemPage({ params, searchParams }: Props) {
+  const [{ boardId, competitionId, userId }, sp, user, locale] = await Promise.all([params, searchParams, getCurrentUser(), getLocale()]);
+  if (!user) notFound();
+
+  const boardIdNum = Number(boardId);
+  const competitionIdNum = Number(competitionId);
+  if (![boardIdNum, competitionIdNum].every(Number.isFinite)) notFound();
+
+  const [boardsRes, leaderboardRes, pickemRes, standingsRes, matchesRes] = await Promise.all([
+    serverApi.get<BoardListItem[]>("/api/boards", { authenticated: true, next: { revalidate: 30, tags: [BOARDS_LIST_TAG] } }),
+    // limit=100 covers a typical board in one page, giving the member's identity,
+    // rank and points; the query-param fallback below covers anyone past it.
+    serverApi.get<LeaderboardEntry[]>(`/api/boards/${boardIdNum}/competitions/${competitionIdNum}/leaderboard?limit=100`, {
+      authenticated: true,
+      next: { revalidate: 30, tags: [leaderboardTag(boardIdNum, competitionIdNum), boardLeaderboardsTag(boardIdNum)] },
+    }),
+    serverApi.get<UserPickem>(`/api/boards/${boardIdNum}/members/${userId}/pickem`, {
+      authenticated: true,
+      next: { revalidate: 60, tags: [memberPickemTag(boardIdNum, userId)] },
+    }),
+    // Actual results the member's predictions are scored against.
+    serverApi.get<StandingRow[]>("/api/standings", { authenticated: false, next: { revalidate: 60, tags: [STANDINGS_CACHE_TAG] } }),
+    serverApi.get<Match[]>("/api/matches", { authenticated: true, next: { revalidate: 60, tags: [MATCHES_CACHE_TAG] } }),
+  ]);
+
+  if (!boardsRes.success) throw new Error(boardsRes.error?.message ?? "Failed to load boards");
+  const boards = boardsRes.data ?? [];
+
+  // Mirror the competition page's self-healing: missing board or non-member bounces to a fallback.
+  const isMember = boards.some((b) => b.id === boardIdNum);
+  if (!isMember) {
+    const fallback = boards.find((b) => b.privacy === "global") ?? boards[0];
+    if (fallback) redirect({ href: `/boards/${fallback.id}?notice=board-not-found`, locale });
+    notFound();
+  }
+
+  const entry = leaderboardRes.success ? (leaderboardRes.data ?? []).find((e) => e.member.user_id === userId) : undefined;
+  const member: LeaderboardMember = entry?.member ?? buildMemberFromQuery(userId, sp);
+
+  // The endpoint only reveals a member's pick'em after the tournament locks (it
+  // 403s before). Rather than bouncing — which reads as a broken navigation — we
+  // render the view and let it show a "not revealed yet" state.
+  const pickem = pickemRes.success ? (pickemRes.data ?? null) : null;
+
+  return (
+    <MemberPickemView
+      boardId={boardIdNum}
+      competitionId={competitionIdNum}
+      member={member}
+      rank={entry?.rank ?? null}
+      score={entry ? (entry.score as PickemScore) : null}
+      pickem={pickem}
+      standings={standingsRes.success ? (standingsRes.data ?? []) : []}
+      matches={matchesRes.success ? (matchesRes.data ?? []) : []}
+    />
+  );
+}
+
+// Roster-shaped member from the link's display name + handle, so the header reads
+// correctly without a leaderboard hit. The name is split into first/last so
+// `displayName`/`getInitials` reproduce it; falls back to a bare handle.
+function buildMemberFromQuery(userId: string, sp: { n?: string; u?: string }): LeaderboardMember {
+  const name = sp.n?.trim();
+  const username = sp.u?.trim() ?? "";
+  if (!name) return { user_id: userId, username, first_name: null, last_name: null };
+  const parts = name.split(/\s+/);
+  return {
+    user_id: userId,
+    username,
+    first_name: parts[0] || null,
+    last_name: parts.length > 1 ? parts.slice(1).join(" ") : null,
+  };
+}

--- a/src/features/bracket/components/BracketCompareLegend.tsx
+++ b/src/features/bracket/components/BracketCompareLegend.tsx
@@ -11,8 +11,18 @@ type Props = {
   summary: BracketCompareSummary;
 };
 
-// Rounds in scoring order, rendered as compact chips.
+// Rounds in scoring order, rendered as compact chips. The reach rounds show the
+// transition they reward — "R32 → R16 +4" — to make clear the points are for
+// *winning* that round (advancing), not for reaching it. The third-place match
+// and final are terminal (win the match), so they show a single label.
 const SCORING_ORDER: BracketStageCode[] = ["round_of_32", "round_of_16", "quarterfinals", "semifinals", "third_place", "final"];
+
+const NEXT_STAGE: Partial<Record<BracketStageCode, BracketStageCode>> = {
+  round_of_32: "round_of_16",
+  round_of_16: "quarterfinals",
+  quarterfinals: "semifinals",
+  semifinals: "final",
+};
 
 /**
  * Compare-mode legend: the running score up top, the green-check meaning, and a
@@ -21,6 +31,10 @@ const SCORING_ORDER: BracketStageCode[] = ["round_of_32", "round_of_16", "quarte
 export function BracketCompareLegend({ summary }: Props) {
   const t = useTranslations("bracket.legend");
   const tShort = useTranslations("pickems.bracket.roundsShort");
+  const tBracket = useTranslations("pickems.bracket");
+
+  // Winning the final means becoming champion — label it as the prize, not the round.
+  const stageLabel = (stage: BracketStageCode) => (stage === "final" ? tBracket("champion") : tShort(stage));
 
   return (
     <section aria-label={t("title")} className="flex flex-col gap-3.5 rounded-xl border border-border bg-card p-4">
@@ -35,25 +49,54 @@ export function BracketCompareLegend({ summary }: Props) {
             <span className="text-muted-foreground">{t("correctHelp")}</span>
           </p>
         </div>
-        <div className="flex shrink-0 flex-col items-end leading-none">
-          <span className="flex items-baseline gap-1">
-            <span className="text-xl font-bold tabular-nums text-page-accent">{summary.earned}</span>
-            <span className="text-sm tabular-nums text-muted-foreground">/ {summary.possible}</span>
-            <span className="ml-0.5 text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("pointsLabel")}</span>
-          </span>
-          <span className="mt-1 text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("earnedPossible")}</span>
-        </div>
+        {/* No matches decided yet → the tally would read "0 / 0", so we drop it and
+            leave just the scoring key until the first knockout result lands. */}
+        {summary.possible > 0 && (
+          <div className="flex shrink-0 flex-col items-end leading-none">
+            <span className="flex items-baseline gap-1">
+              <span className="text-xl font-bold tabular-nums text-page-accent">{summary.earned}</span>
+              <span className="text-sm tabular-nums text-muted-foreground">/ {summary.possible}</span>
+              <span className="ml-0.5 text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("pointsLabel")}</span>
+            </span>
+            <span className="mt-1 text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("earnedPossible")}</span>
+          </div>
+        )}
       </div>
 
       <div className="flex flex-col gap-2 border-t border-border pt-3">
         <p className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("scoringTitle")}</p>
         <ul className="flex flex-wrap gap-1.5">
-          {SCORING_ORDER.map((stage) => (
-            <li key={stage} className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-muted/40 px-2 py-1">
-              <span className="text-xs font-medium text-foreground">{tShort(stage)}</span>
-              <span className="font-mono text-xs font-semibold text-page-accent">+{STAGE_POINTS[stage]}</span>
-            </li>
-          ))}
+          {SCORING_ORDER.map((stage) => {
+            const next = NEXT_STAGE[stage];
+            // Once a round has decided matches, show the member's earned / attainable
+            // for it; before then show the per-team rule so it reads as a scoring key.
+            const stat = summary.byStage.get(stage);
+            const decided = stat != null && stat.possible > 0;
+            return (
+              <li key={stage} className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-muted/40 px-2 py-1">
+                <span className="inline-flex items-center gap-1 text-xs font-medium text-foreground">
+                  {stageLabel(stage)}
+                  {next ? (
+                    <>
+                      <span aria-hidden className="text-muted-foreground">
+                        →
+                      </span>
+                      {tShort(next)}
+                    </>
+                  ) : null}
+                </span>
+                <div className="flex items-center gap-1.5">
+                  <span className="font-mono text-xs font-semibold text-page-accent">+{STAGE_POINTS[stage]}</span>
+                  {decided && (
+                    <span className="font-mono text-xs font-semibold tabular-nums">
+                      <span className="text-page-accent">{stat.earned}</span>
+                      <span className="text-muted-foreground">/{stat.possible}</span>
+                    </span>
+                  )}
+                </div>
+              </li>
+            );
+          })}
         </ul>
       </div>
     </section>

--- a/src/features/bracket/components/BracketView.tsx
+++ b/src/features/bracket/components/BracketView.tsx
@@ -87,7 +87,7 @@ export function BracketView({ initialMatches, initialPickem, isAuthed }: Props) 
         <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">{comparing ? t("descriptionCompare") : t("description")}</p>
       </header>
 
-      {comparing && summary && summary.possible > 0 && <BracketCompareLegend summary={summary} />}
+      {comparing && summary && <BracketCompareLegend summary={summary} />}
 
       <BracketTree bracket={actualSlots} champion={champion} disabled comparisonById={comparisonById} />
     </div>

--- a/src/features/bracket/lib/bracketCompare.ts
+++ b/src/features/bracket/lib/bracketCompare.ts
@@ -4,13 +4,14 @@ import type { BracketMatchSlot, BracketStageCode } from "@/features/pickems/type
 import type { BracketCompareSummary, SlotComparison } from "../types/bracket.types";
 
 /**
- * Official knockout bracket point values (mirrors the `/rules` table). Scoring is
- * cumulative per team: a team that goes all the way scores at every round it
- * reached — e.g. a correctly-predicted champion earns R32+R16+QF+SF (4+6+8+12)
- * for reaching each round, plus the champion bonus (20) = 50, not just 20.
+ * Official knockout bracket point values (mirrors the `/rules` table). Points are
+ * earned by **advancing past** a round, not by reaching it: winning a Round-of-32
+ * match earns its 4, winning the Round-of-16 earns 6, and so on. A correctly
+ * predicted champion wins R32+R16+QF+SF+Final = 4+6+8+12+20 = 50.
  *
- * R32/R16/QF/SF score "per correct team that reaches this round"; the
- * third-place match and final score the correct *winner* only.
+ * Reaching the Round of 32 is the group stage's job (qualifier points), so it is
+ * not bracket-scored — but the bracket still *highlights* a correctly predicted
+ * R32 team (see `buildComparisonMap`) to show the group call was right.
  */
 export const STAGE_POINTS: Record<BracketStageCode, number> = {
   round_of_32: 4,
@@ -21,15 +22,15 @@ export const STAGE_POINTS: Record<BracketStageCode, number> = {
   final: 20,
 };
 
-// Stages graded on "did this team reach the round" (both teams in the match).
+// Rounds whose green check means "this team reached the round" (both sides of the
+// match light up). The final / third-place match light up the winner only.
 const REACH_STAGES = new Set<BracketStageCode>(["round_of_32", "round_of_16", "quarterfinals", "semifinals"]);
 
 type PredictedInfo = {
-  /** Per stage, the fifa codes of teams the user predicted to reach it. */
+  /** Per stage, the fifa codes of teams predicted to reach it. */
   teamsByStage: Map<BracketStageCode, Set<string>>;
-  /** The user's predicted champion (Final winner). */
+  /** Predicted champion (Final winner) and third-place-match winner. */
   championCode: string | null;
-  /** The user's predicted third-place match winner. */
   thirdWinnerCode: string | null;
 };
 
@@ -51,7 +52,7 @@ function buildPredictedInfo(predicted: BracketMatchSlot[]): PredictedInfo {
   return { teamsByStage, championCode, thirdWinnerCode };
 }
 
-/** Did the user predict `code` to reach (or, for final/third, win) this stage? */
+/** Did the prediction place `code` in (or, for final/third, win) this stage? */
 function userPredicted(stage: BracketStageCode, code: string | undefined, info: PredictedInfo): boolean {
   if (!code) return false;
   if (REACH_STAGES.has(stage)) return info.teamsByStage.get(stage)?.has(code) ?? false;
@@ -61,10 +62,10 @@ function userPredicted(stage: BracketStageCode, code: string | undefined, info: 
 }
 
 /**
- * Compare overlay for the **actual** bracket: green-check each real team that
- * the user correctly predicted to reach this match's stage. For the final and
- * third-place match only the actual winner row can light up (those score the
- * winner, not participation).
+ * Compare overlay for the **actual** bracket: green-check each real team the user
+ * correctly predicted to *reach* this match's stage — including the Round of 32,
+ * which confirms the group call even though it earns no bracket points. The final
+ * and third-place match light up only the actual winner row.
  */
 export function buildComparisonMap(actual: BracketMatchSlot[], predicted: BracketMatchSlot[]): Map<number, SlotComparison> {
   const info = buildPredictedInfo(predicted);
@@ -92,46 +93,44 @@ export function buildComparisonMap(actual: BracketMatchSlot[], predicted: Bracke
   return map;
 }
 
+/** Per stage, the fifa codes of the teams that won their match at that stage. */
+function winnersByStage(slots: BracketMatchSlot[]): Map<BracketStageCode, Set<string>> {
+  const map = new Map<BracketStageCode, Set<string>>();
+  for (const slot of slots) {
+    const winner = slot.picked_team?.fifa_code;
+    if (!winner) continue;
+    const set = map.get(slot.stage_code) ?? new Set<string>();
+    set.add(winner);
+    map.set(slot.stage_code, set);
+  }
+  return map;
+}
+
 /**
- * Aggregate earned vs. attainable points, computed against what's actually been
- * decided. Cumulative by construction: each reach-stage is scored independently,
- * so a team that advanced far contributes at every round it reached.
+ * Aggregate earned vs. attainable points, against what's actually been decided.
+ * Points are for *advancing*: each decided match is worth its round's value to
+ * whoever wins it, and the user earns it when their predicted winner is the real
+ * one. Reaching the R32 is not counted here (it's group-stage scoring).
  */
 export function summarizeBracket(actual: BracketMatchSlot[], predicted: BracketMatchSlot[]): BracketCompareSummary {
-  const info = buildPredictedInfo(predicted);
+  const predictedWinners = winnersByStage(predicted);
+  const byStage = new Map<BracketStageCode, { earned: number; possible: number }>();
   let earned = 0;
   let possible = 0;
 
-  for (const stage of REACH_STAGES) {
-    const predictedTeams = info.teamsByStage.get(stage);
-    const points = STAGE_POINTS[stage];
-    let actualCount = 0;
-    let correct = 0;
-
-    for (const slot of actual) {
-      if (slot.stage_code !== stage) continue;
-      for (const team of [slot.home_team, slot.away_team]) {
-        if (!team) continue;
-        actualCount += 1;
-        if (predictedTeams?.has(team.fifa_code)) correct += 1;
-      }
+  for (const slot of actual) {
+    const winnerCode = slot.picked_team?.fifa_code;
+    if (!winnerCode) continue; // match not decided yet
+    const points = STAGE_POINTS[slot.stage_code];
+    const stat = byStage.get(slot.stage_code) ?? { earned: 0, possible: 0 };
+    stat.possible += points;
+    possible += points;
+    if (predictedWinners.get(slot.stage_code)?.has(winnerCode)) {
+      stat.earned += points;
+      earned += points;
     }
-
-    if (actualCount === 0) continue; // stage not decided yet
-    earned += correct * points;
-    possible += actualCount * points; // max attainable = teams that actually reached
+    byStage.set(slot.stage_code, stat);
   }
 
-  const actualChampion = actual.find((s) => s.match_id === FINAL_MATCH_ID)?.picked_team?.fifa_code ?? null;
-  if (actualChampion) {
-    possible += STAGE_POINTS.final;
-    if (info.championCode === actualChampion) earned += STAGE_POINTS.final;
-  }
-  const actualThird = actual.find((s) => s.match_id === THIRD_PLACE_MATCH_ID)?.picked_team?.fifa_code ?? null;
-  if (actualThird) {
-    possible += STAGE_POINTS.third_place;
-    if (info.thirdWinnerCode === actualThird) earned += STAGE_POINTS.third_place;
-  }
-
-  return { earned, possible };
+  return { earned, possible, byStage };
 }

--- a/src/features/bracket/types/bracket.types.ts
+++ b/src/features/bracket/types/bracket.types.ts
@@ -1,4 +1,4 @@
-import type { BracketMatchCompare } from "@/features/pickems/types/pickems.types";
+import type { BracketMatchCompare, BracketStageCode } from "@/features/pickems/types/pickems.types";
 
 /** Which bracket view is active. Persisted in the URL (`?view=compare`). */
 export type BracketViewMode = "results" | "compare";
@@ -6,13 +6,19 @@ export type BracketViewMode = "results" | "compare";
 /** Per-match team-correctness overlay, keyed by match id. Re-exported shape. */
 export type SlotComparison = BracketMatchCompare;
 
+/** Earned vs. attainable points for a single round. */
+export type BracketStagePoints = { earned: number; possible: number };
+
 /**
  * Aggregate compare totals shown in the legend: points the user has earned so
- * far against the maximum still attainable from matches that have been decided.
+ * far against the maximum still attainable from matches that have been decided,
+ * with the per-round breakdown (e.g. "R32 → R16: 40 / 64").
  */
 export type BracketCompareSummary = {
   /** Points earned for correctly predicted advancers (official per-round values). */
   earned: number;
   /** Max points earnable given the stages decided so far (the denominator). */
   possible: number;
+  /** Per-round earned / possible split. */
+  byStage: Map<BracketStageCode, BracketStagePoints>;
 };

--- a/src/features/competitions/api/memberPickem.ts
+++ b/src/features/competitions/api/memberPickem.ts
@@ -1,0 +1,17 @@
+import type { UserPickem } from "@/features/pickems/types/pickems.types";
+import { api } from "@/shared/lib/api/client";
+
+// A board member's committed tournament pick'em. The endpoint returns the same
+// bare `UserPickem` the viewer's own `/api/pickems` does (no member wrapping), so
+// the read-only renderers consume it directly; the member's identity comes from
+// the competition leaderboard. Only revealed once the tournament has locked
+// (the upstream 403s before kickoff) — callers expose the entry point only then.
+
+export const memberPickemTag = (boardId: number, userId: string) => `member-pickem:${boardId}:${userId}` as const;
+export const memberPickemKey = (boardId: number, userId: string) => ["member-pickem", boardId, userId] as const;
+
+export async function fetchMemberPickem(boardId: number, userId: string): Promise<UserPickem> {
+  const res = await api.get<UserPickem>(`/api/boards/${boardId}/members/${userId}/pickem`, { authenticated: true });
+  if (!res.success || !res.data) throw new Error(res.error?.message ?? "Failed to load member pick'em");
+  return res.data;
+}

--- a/src/features/competitions/components/CompetitionDetailView.tsx
+++ b/src/features/competitions/components/CompetitionDetailView.tsx
@@ -45,6 +45,10 @@ export function CompetitionDetailView({ currentUserId, board, competition, match
   const revealable = useMemo(() => (competition.type === "match" ? revealableMatches(competition, matches, now) : []), [competition, matches, now]);
   const revealAvailable = revealable.length > 0;
 
+  // The per-row eye reveals a member's predictions — match competitions open the
+  // per-match dialog in place; a locked pick'em links to the member's full pick'em.
+  const revealMode: "dialog" | "navigate" | undefined = revealAvailable ? "dialog" : competition.type === "pickem" && pickem?.isLocked ? "navigate" : undefined;
+
   // A pick whose match has locked: the breakdown carries the leaderboard, so the
   // ranked table below is dropped to avoid duplicate member lists.
   const pickBreakdown = isPick && breakdownInitial ? breakdownInitial : null;
@@ -97,13 +101,7 @@ export function CompetitionDetailView({ currentUserId, board, competition, match
           </Reveal>
 
           <Reveal from="up" trigger="mount" delay={0.14}>
-            <LeaderboardSection
-              boardId={board.id}
-              competition={competition}
-              currentUserId={currentUserId}
-              initialData={initialLeaderboard}
-              revealAvailable={revealAvailable}
-            />
+            <LeaderboardSection boardId={board.id} competition={competition} currentUserId={currentUserId} initialData={initialLeaderboard} revealMode={revealMode} />
           </Reveal>
         </>
       )}

--- a/src/features/competitions/components/LeaderboardSection.tsx
+++ b/src/features/competitions/components/LeaderboardSection.tsx
@@ -4,9 +4,12 @@ import { useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 
+import { useRouter as useIntlRouter } from "@/i18n/navigation";
+
 import { LEADERBOARD_PAGE_SIZE } from "../api/competitions";
 import { useLeaderboard } from "../hooks/useLeaderboard";
 import { buildColumns, buildMobileCyclableColumns } from "../lib/competitionColumns";
+import { memberPickemPath } from "../lib/memberPickemUrl";
 import type { Competition, LeaderboardEntry, LeaderboardPage } from "../types/competitions.types";
 
 import { LeaderboardMobileTable } from "./LeaderboardMobileTable";
@@ -19,8 +22,10 @@ type Props = {
   competition: Competition;
   currentUserId: string;
   initialData: LeaderboardPage | null;
-  // Enables the per-row eye action that reveals a member's predictions.
-  revealAvailable?: boolean;
+  // Enables the per-row eye action that reveals a member's predictions:
+  //   "dialog"   — match competitions: open the per-match picks dialog in place.
+  //   "navigate" — pick'em competitions: go to the member's full pick'em page.
+  revealMode?: "dialog" | "navigate";
 };
 
 const PAGE_PARAM = "page";
@@ -28,16 +33,21 @@ const Q_PARAM = "q";
 const SORT_PARAM = "sort";
 const DIR_PARAM = "dir";
 
-export function LeaderboardSection({ boardId, competition, currentUserId, initialData, revealAvailable = false }: Props) {
+export function LeaderboardSection({ boardId, competition, currentUserId, initialData, revealMode }: Props) {
   const t = useTranslations("competitions.leaderboard");
   const router = useRouter();
+  const intlRouter = useIntlRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState<LeaderboardEntry | null>(null);
-  const onViewMember = revealAvailable
+  const onViewMember = revealMode
     ? (entry: LeaderboardEntry) => {
+        if (revealMode === "navigate") {
+          intlRouter.push(memberPickemPath(boardId, competition.id, entry.member));
+          return;
+        }
         setSelected(entry);
         setOpen(true);
       }
@@ -141,7 +151,7 @@ export function LeaderboardSection({ boardId, competition, currentUserId, initia
         </div>
       ) : null}
 
-      {revealAvailable ? (
+      {revealMode === "dialog" ? (
         <MemberPicksDialog
           open={open}
           onOpenChange={setOpen}

--- a/src/features/competitions/components/pickemReveal/MemberPickemSkeleton.tsx
+++ b/src/features/competitions/components/pickemReveal/MemberPickemSkeleton.tsx
@@ -1,0 +1,60 @@
+import { Skeleton } from "@/shared/components/ui/skeleton";
+
+// Mirrors MemberPickemView 1:1 — back link, identity header, stat pills, and the
+// three stacked sections (groups grid, thirds grid, bracket) — to avoid layout
+// shift when the real content resolves.
+export function MemberPickemSkeleton() {
+  return (
+    <section className="container flex flex-col gap-6 pt-6 pb-10 lg:pt-8 lg:pb-12">
+      <Skeleton className="h-5 w-32" />
+
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-12 rounded-full" />
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-6 w-40" />
+            <Skeleton className="h-3.5 w-24" />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-2.5 sm:max-w-sm">
+          <Skeleton className="h-12 rounded-lg" />
+          <Skeleton className="h-12 rounded-lg" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-10">
+        <SectionSkeleton>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-36 rounded-lg" />
+            ))}
+          </div>
+        </SectionSkeleton>
+
+        <SectionSkeleton>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-14 rounded-xl" />
+            ))}
+          </div>
+        </SectionSkeleton>
+
+        <SectionSkeleton>
+          <Skeleton className="h-72 rounded-xl" />
+        </SectionSkeleton>
+      </div>
+    </section>
+  );
+}
+
+function SectionSkeleton({ children }: { children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Skeleton className="size-8 rounded-lg" />
+        <Skeleton className="h-6 w-28" />
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/src/features/competitions/components/pickemReveal/MemberPickemView.tsx
+++ b/src/features/competitions/components/pickemReveal/MemberPickemView.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, ChevronsUpDown, Hash, ListOrdered, Lock, Star, Trophy } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import type { UserPickem } from "@/features/pickems/types/pickems.types";
+import type { Match } from "@/features/schedule/types/schedule.types";
+import { getAccuracyPillClass, getThirdPlacePillClass } from "@/features/standings/lib/comparison";
+import type { PickAccuracy, StandingRow, ThirdPlaceAccuracy } from "@/features/standings/types/standings.types";
+import { Link } from "@/i18n/navigation";
+import { MemberAvatar } from "@/shared/components/MemberAvatar";
+import { Reveal } from "@/shared/components/Reveal";
+import { Button } from "@/shared/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
+import { useIsMobile } from "@/shared/hooks/useMediaQuery";
+import { displayName } from "@/shared/lib/ui";
+import { cn } from "@/shared/lib/utils";
+
+import { buildGroupReveal, buildThirdsReveal } from "../../lib/pickemRevealCompare";
+import type { LeaderboardMember, PickemScore } from "../../types/competitions.types";
+
+import { RevealBestThirds } from "./RevealBestThirds";
+import { RevealBracket } from "./RevealBracket";
+import { RevealGroupCard } from "./RevealGroupCard";
+
+type Props = {
+  boardId: number;
+  competitionId: number;
+  member: LeaderboardMember;
+  // From the competition leaderboard — omitted when the member sits past the lookup window.
+  rank: number | null;
+  score: PickemScore | null;
+  // null when the tournament hasn't locked yet (predictions stay hidden until then).
+  pickem: UserPickem | null;
+  // Live results the member's predictions are scored against.
+  standings: StandingRow[];
+  matches: Match[];
+};
+
+export function MemberPickemView({ boardId, competitionId, member, rank, score, pickem, standings, matches }: Props) {
+  const t = useTranslations("competitions.memberPickem");
+  const isMobile = useIsMobile();
+  const name = displayName(member.username, member.first_name, member.last_name);
+  const backHref = `/boards/${boardId}/competitions/${competitionId}`;
+
+  // A member who made no pick'em can come back with missing arrays — default them
+  // so the sections still render (empty groups, "—" thirds, no bracket checks).
+  const groupPicks = pickem?.group_picks ?? [];
+  const bestThirds = pickem?.best_thirds ?? [];
+  const bracketSlots = pickem?.bracket ?? [];
+
+  // The leaderboard score is the source of truth for points — the member endpoint
+  // returns a fully-seeded, locked pickem even for members who never played, so we
+  // grade a section only where the board actually credited points; otherwise every
+  // pick reads "not picked" (`—`).
+  const groupsScored = (score?.group_exact_positions ?? 0) > 0 || (score?.group_qualifier_hits ?? 0) > 0;
+  const thirdsScored = (score?.best_third_hits ?? 0) > 0;
+  // The bracket greens correctly predicted reaches (incl. the R32 group call, which
+  // scores no bracket points), so it gates on having played at all, not on bracket points.
+  const participated = (score?.total ?? 0) > 0;
+
+  const groupReveal = pickem ? buildGroupReveal(groupPicks, standings, groupsScored) : null;
+  const thirdsReveal = pickem ? buildThirdsReveal(bestThirds, standings, thirdsScored) : null;
+  const groupsDecided = groupReveal ? [...groupReveal.values()].some((g) => g.decided) : false;
+
+  // Group cards are expanded by default; the parent owns the open set so one
+  // toggle can expand / collapse them all.
+  const groupCodes = groupPicks.map((g) => g.group_code);
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set(groupCodes));
+  const allGroupsExpanded = groupCodes.length > 0 && groupCodes.every((c) => expandedGroups.has(c));
+  const toggleGroup = (code: string) =>
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(code)) next.delete(code);
+      else next.add(code);
+      return next;
+    });
+  const toggleAllGroups = () => setExpandedGroups(allGroupsExpanded ? new Set() : new Set(groupCodes));
+
+  // Total group points earned vs. attainable from the finished groups — the same
+  // earned / possible read the bracket legend gives.
+  const groupTally = groupReveal
+    ? [...groupReveal.values()].reduce((acc, g) => (g.summary ? { earned: acc.earned + g.summary.points, possible: acc.possible + g.summary.maxPoints } : acc), {
+        earned: 0,
+        possible: 0,
+      })
+    : { earned: 0, possible: 0 };
+
+  const groupsSection = (
+    <Reveal from="up" trigger="mount" delay={0.06}>
+      <Section icon={ListOrdered} title={t("sections.groups")}>
+        {groupsDecided ? <GroupsLegend earned={groupTally.earned} possible={groupTally.possible} /> : null}
+        {groupPicks.length > 0 ? (
+          <div className="flex justify-end">
+            <Button type="button" variant="outline" size="sm" onClick={toggleAllGroups} className="min-w-32 cursor-pointer gap-1.5">
+              <ChevronsUpDown className="size-3.5" aria-hidden />
+              {allGroupsExpanded ? t("collapseAll") : t("expandAll")}
+            </Button>
+          </div>
+        ) : null}
+        {/* items-start so expanding one card doesn't stretch its row-mates to match. */}
+        <div className="grid grid-cols-1 items-start gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {groupPicks.map((group) => (
+            <RevealGroupCard
+              key={group.group_code}
+              group={group}
+              data={groupReveal?.get(group.group_code)}
+              open={expandedGroups.has(group.group_code)}
+              onToggle={() => toggleGroup(group.group_code)}
+            />
+          ))}
+        </div>
+      </Section>
+    </Reveal>
+  );
+
+  const thirdsSection = (
+    <Reveal from="up" trigger="mount" delay={0.1}>
+      <Section icon={Star} title={t("sections.thirds")}>
+        {thirdsReveal && thirdsReveal.rows.length > 0 ? <ThirdsLegend /> : null}
+        <RevealBestThirds picks={bestThirds} reveal={thirdsReveal ?? undefined} />
+      </Section>
+    </Reveal>
+  );
+
+  const bracketSection = (
+    <Reveal from="up" trigger="mount" delay={0.14}>
+      <Section icon={Trophy} title={t("sections.bracket")}>
+        <RevealBracket bracket={bracketSlots} matches={matches} participated={participated} />
+      </Section>
+    </Reveal>
+  );
+
+  return (
+    <section className="container flex flex-col gap-6 pt-6 pb-10 lg:pt-8 lg:pb-12">
+      <Link href={backHref} className="inline-flex w-fit items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
+        <ChevronLeft className="size-4" aria-hidden />
+        {t("back")}
+      </Link>
+
+      <Reveal from="up" trigger="mount">
+        <header className="flex flex-col gap-4">
+          <div className="flex items-center gap-3">
+            <MemberAvatar username={member.username} firstName={member.first_name} lastName={member.last_name} neutral className="size-12" fallbackClassName="text-sm" />
+            <div className="flex min-w-0 flex-col leading-tight">
+              <h1 className="truncate font-heading text-xl font-bold tracking-tight sm:text-2xl">{name}</h1>
+              {member.username ? <span className="truncate text-sm text-muted-foreground">@{member.username}</span> : null}
+            </div>
+          </div>
+
+          {score ? <ScoreBreakdown score={score} rank={rank} /> : null}
+        </header>
+      </Reveal>
+
+      {!pickem ? (
+        <div className="flex flex-col items-center gap-3 rounded-xl border border-foreground/10 bg-card px-6 py-12 text-center shadow-xs">
+          <span className="grid size-12 place-items-center rounded-full bg-muted text-muted-foreground">
+            <Lock className="size-5" aria-hidden />
+          </span>
+          <div className="flex flex-col gap-1">
+            <p className="font-heading text-base font-semibold">{t("locked.title")}</p>
+            <p className="max-w-sm text-sm text-muted-foreground">{t("locked.description")}</p>
+          </div>
+        </div>
+      ) : isMobile ? (
+        // Mobile: split the two stages into tabs so each fits the viewport and the
+        // bracket gets the full width it needs.
+        <Tabs defaultValue="groups">
+          <TabsList className="w-full">
+            <TabsTrigger value="groups">{t("tabs.groups")}</TabsTrigger>
+            <TabsTrigger value="knockout">{t("tabs.knockout")}</TabsTrigger>
+          </TabsList>
+          <TabsContent value="groups" className="mt-6 flex flex-col gap-10">
+            {groupsSection}
+            {thirdsSection}
+          </TabsContent>
+          <TabsContent value="knockout" className="mt-6">
+            {bracketSection}
+          </TabsContent>
+        </Tabs>
+      ) : (
+        <div className="flex flex-col gap-10">
+          {groupsSection}
+          {thirdsSection}
+          {bracketSection}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// The points the member earned, as the board scores them: total up top, then the
+// same per-category breakdown the leaderboard shows.
+function ScoreBreakdown({ score, rank }: { score: PickemScore; rank: number | null }) {
+  const t = useTranslations("competitions.memberPickem");
+  const tCols = useTranslations("competitions.leaderboard.columnsLong");
+
+  // Scoring rules: exact groups +3, qualifiers +1, best thirds +2, bracket varies by round
+  const metrics: { label: string; value: number; points: number }[] = [
+    { label: tCols("groupExact"), value: score.group_exact_positions, points: score.group_exact_positions * 3 },
+    { label: tCols("groupQualifiers"), value: score.group_qualifier_hits, points: score.group_qualifier_hits * 1 },
+    { label: tCols("bestThirds"), value: score.best_third_hits, points: score.best_third_hits * 2 },
+    {
+      label: tCols("bracket"),
+      value: score.bracket_hits,
+      points: score.total - (score.group_exact_positions * 3 + score.group_qualifier_hits * 1 + score.best_third_hits * 2),
+    },
+  ];
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="flex items-end justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <span className="inline-flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wider text-muted-foreground">
+            <Star className="size-3.5 text-page-accent-strong" aria-hidden />
+            {t("score.total")}
+          </span>
+          <span className="font-heading text-3xl font-bold tabular-nums leading-none">{score.total.toLocaleString()}</span>
+        </div>
+        {rank !== null ? (
+          <span className="inline-flex items-center gap-1 rounded-lg border border-border/60 px-3 py-1.5 text-sm font-semibold tabular-nums">
+            <Hash className="size-3.5 text-page-accent-strong" aria-hidden />
+            {rank}
+          </span>
+        ) : null}
+      </div>
+
+      <dl className="mt-4 grid grid-cols-2 gap-2 border-t border-border pt-3 sm:grid-cols-4">
+        {metrics.map((metric) => (
+          <div key={metric.label} className="flex flex-col gap-0.5">
+            <dt className="truncate text-2xs font-medium uppercase tracking-wider text-muted-foreground">{metric.label}</dt>
+            <dd className="flex items-baseline gap-1.5 font-heading text-base font-semibold tabular-nums">
+              <span>{metric.value.toLocaleString()}</span>
+              <span className="text-xs font-medium text-page-accent">+{metric.points.toLocaleString()}</span>
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+const pillBase = "inline-flex h-5 min-w-5 items-center justify-center rounded-full border px-1 text-2xs font-semibold tabular-nums";
+
+// "How to read" key for the group position circles — mirrors `/standings`, with
+// the earned / possible group-points tally read the same way as the bracket legend.
+function GroupsLegend({ earned, possible }: { earned: number; possible: number }) {
+  const t = useTranslations("competitions.memberPickem.groupsLegend");
+  const items: { accuracy: PickAccuracy; content: string; label: string }[] = [
+    { accuracy: "exact_3pts", content: "1", label: t("exact") },
+    { accuracy: "top2_1pt", content: "1", label: t("top2") },
+    { accuracy: "wrong_0pts", content: "1", label: t("wrong") },
+    { accuracy: "not_picked", content: "—", label: t("notPicked") },
+  ];
+  return (
+    <section aria-label={t("title")} className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-2">
+          <p className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("title")}</p>
+          <p className="text-xs font-semibold text-foreground">{t("help")}</p>
+        </div>
+        {possible > 0 && (
+          <div className="flex shrink-0 flex-col items-end leading-none">
+            <span className="flex items-baseline gap-1">
+              <span className="text-xl font-bold tabular-nums text-page-accent">{earned}</span>
+              <span className="text-sm tabular-nums text-muted-foreground">/ {possible}</span>
+              <span className="ml-0.5 text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("pointsLabel")}</span>
+            </span>
+            <span className="mt-1 text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("earnedPossible")}</span>
+          </div>
+        )}
+      </div>
+      <ul className="grid grid-cols-1 gap-2 text-xs text-muted-foreground sm:grid-cols-2 xl:grid-cols-4">
+        {items.map((item) => (
+          <li key={item.label} className="flex items-center gap-2">
+            <span className={cn(pillBase, getAccuracyPillClass(item.accuracy))}>{item.content}</span>
+            {item.label}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+// "How to read" key for the best-thirds circles — mirrors `/standings`: ✓ correct,
+// ✕ wrong, — not picked. No points tally, just the key.
+function ThirdsLegend() {
+  const t = useTranslations("competitions.memberPickem.thirdsLegend");
+  const items: { accuracy: ThirdPlaceAccuracy; content: string; label: string }[] = [
+    { accuracy: "correct", content: "✓", label: t("correct") },
+    { accuracy: "wrong", content: "✕", label: t("wrong") },
+    { accuracy: "not_picked", content: "—", label: t("notPicked") },
+  ];
+  return (
+    <section aria-label={t("title")} className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">
+      <p className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("title")}</p>
+      <p className="text-xs font-semibold text-foreground">{t("help")}</p>
+      <ul className="grid grid-cols-1 gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+        {items.map((item) => (
+          <li key={item.label} className="flex items-center gap-2">
+            <span className={cn(pillBase, getThirdPlacePillClass(item.accuracy))}>{item.content}</span>
+            {item.label}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function Section({
+  icon: Icon,
+  title,
+  children,
+}: {
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-page-accent-soft">
+          <Icon className="size-4 text-page-accent-strong" aria-hidden />
+        </span>
+        <h2 className="text-lg font-semibold tracking-tight text-foreground">{title}</h2>
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/src/features/competitions/components/pickemReveal/RevealBestThirds.tsx
+++ b/src/features/competitions/components/pickemReveal/RevealBestThirds.tsx
@@ -1,0 +1,80 @@
+import Image from "next/image";
+import { useLocale, useTranslations } from "next-intl";
+
+import { getThirdPlacePillClass } from "@/features/standings/lib/comparison";
+import type { ThirdPlaceAccuracy } from "@/features/standings/types/standings.types";
+import { getTeamName } from "@/shared/lib/getTeamName";
+import { cn } from "@/shared/lib/utils";
+import type { Team } from "@/shared/types/wcp.types";
+
+import type { ThirdsReveal } from "../../lib/pickemRevealCompare";
+
+type Props = {
+  // The member's best-thirds picks — shown only when there's no standings table yet.
+  picks: Team[];
+  // The ranked twelve thirds, graded against the member's picks.
+  reveal?: ThirdsReveal;
+};
+
+// Compact read-only best-thirds card. Mirrors the `/standings` third-place table:
+// the twelve third-placed teams in rank order, the top eight advancing, with the
+// member's pick shown as a ✓ / ✕ / — circle (✓ = an advancing team the member
+// picked, i.e. the one that earned them points).
+export function RevealBestThirds({ picks, reveal }: Props) {
+  const locale = useLocale();
+  const tReveal = useTranslations("competitions.memberPickem");
+
+  if (reveal && reveal.rows.length > 0) {
+    return (
+      <div className="overflow-hidden rounded-lg border border-border bg-card">
+        <ul>
+          {reveal.rows.map((row) => (
+            <li
+              key={row.team.fifa_code}
+              className={cn(
+                "flex items-center gap-2 border-t border-border px-2 py-1 first:border-t-0",
+                row.rank === reveal.qualifyingSlots + 1 && "border-t-2 border-dashed border-muted-foreground/40",
+                !row.advances && "bg-muted/40 text-muted-foreground"
+              )}
+            >
+              <span className={cn("w-4 text-center text-2xs font-semibold tabular-nums", row.advances ? "text-page-accent" : "text-muted-foreground")}>{row.rank}</span>
+              <Image src={row.team.flag_url} alt="" width={20} height={14} className="h-3.5 w-5 shrink-0 rounded-xs object-cover" unoptimized />
+              <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">{getTeamName(row.team, locale)}</span>
+              {row.team.group_code ? <span className="shrink-0 font-mono text-2xs uppercase tracking-wider text-muted-foreground">{row.team.group_code}</span> : null}
+              <PickCircle accuracy={row.accuracy} picked={row.picked} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  // Before the group stage ends — show the member's selections (no scoring yet).
+  if (picks.length === 0) {
+    return <p className="rounded-lg border border-dashed border-border bg-muted/30 px-4 py-8 text-center text-sm text-muted-foreground">{tReveal("thirdsEmpty")}</p>;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <ul>
+        {picks.map((team) => (
+          <li key={team.fifa_code} className="flex items-center gap-2 border-t border-border px-2 py-1 first:border-t-0">
+            <Image src={team.flag_url} alt="" width={20} height={14} className="h-3.5 w-5 shrink-0 rounded-xs object-cover" unoptimized />
+            <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">{getTeamName(team, locale)}</span>
+            {team.group_code ? <span className="shrink-0 font-mono text-2xs uppercase tracking-wider text-muted-foreground">{team.group_code}</span> : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ✓ = picked & advanced (earned points), ✕ = picked but missed, — = not picked.
+// Same circle + palette as the standings third-place "Pick" column.
+function PickCircle({ accuracy, picked }: { accuracy: ThirdPlaceAccuracy; picked: boolean }) {
+  return (
+    <span className={cn("inline-flex h-5 min-w-5 items-center justify-center rounded-full border px-1 text-2xs font-semibold", getThirdPlacePillClass(accuracy))}>
+      {picked ? (accuracy === "correct" ? "✓" : "✕") : "—"}
+    </span>
+  );
+}

--- a/src/features/competitions/components/pickemReveal/RevealBracket.tsx
+++ b/src/features/competitions/components/pickemReveal/RevealBracket.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { BracketCompareLegend } from "@/features/bracket/components/BracketCompareLegend";
+import { summarizeBracket } from "@/features/bracket/lib/bracketCompare";
+import { buildActualBracket } from "@/features/bracket/lib/buildActualBracket";
+import { BracketTree } from "@/features/pickems/components/BracketTree";
+import { findChampion, projectBracket } from "@/features/pickems/lib/projectBracket";
+import type { BracketMatchSlot } from "@/features/pickems/types/pickems.types";
+import type { Match } from "@/features/schedule/types/schedule.types";
+
+import { buildBracketReveal } from "../../lib/pickemRevealCompare";
+
+type Props = {
+  bracket: BracketMatchSlot[];
+  // Live match results the member's bracket is scored against.
+  matches: Match[];
+  // Whether the member actually played (any board points). The seeded member
+  // endpoint hands back a default tree even for non-players, so we only green a
+  // member's picks once they've earned something — otherwise nothing lights up.
+  participated: boolean;
+};
+
+// No local draft — the member's committed picks already live on each slot's
+// `picked_team`; projection only resolves R16+ home/away forward from them.
+const NO_DRAFT = {};
+
+/**
+ * The member's *predicted* knockout tree — their actual picks — reusing the same
+ * `BracketTree` that `/bracket` and `/pickems` step 3 render. Each team greens when
+ * the member correctly predicted it to reach that round — including the Round of
+ * 32, which confirms the group call even though it scores no bracket points. The
+ * earned / possible points legend (points are for advancing) sits on top.
+ */
+export function RevealBracket({ bracket, matches, participated }: Props) {
+  const predictedSlots = useMemo(() => projectBracket(bracket, NO_DRAFT), [bracket]);
+  const actualSlots = useMemo(() => buildActualBracket(matches), [matches]);
+
+  // Keyed on the member's tree: greens the picks they got right. All-false for a
+  // non-player, which keeps the cards in compare mode (no pick accent, no checks).
+  const comparisonById = useMemo(() => buildBracketReveal(predictedSlots, actualSlots, participated), [predictedSlots, actualSlots, participated]);
+  const champion = useMemo(() => findChampion(predictedSlots), [predictedSlots]);
+
+  // Earned/possible tally; a non-player earns nothing, so zero it (overall and
+  // per round) while keeping the attainable totals.
+  const summary = useMemo(() => {
+    const raw = summarizeBracket(actualSlots, predictedSlots);
+    if (participated) return raw;
+    const byStage = new Map([...raw.byStage].map(([stage, s]) => [stage, { earned: 0, possible: s.possible }] as const));
+    return { earned: 0, possible: raw.possible, byStage };
+  }, [participated, actualSlots, predictedSlots]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <BracketCompareLegend summary={summary} />
+      <BracketTree bracket={predictedSlots} champion={champion} disabled comparisonById={comparisonById} />
+    </div>
+  );
+}

--- a/src/features/competitions/components/pickemReveal/RevealGroupCard.tsx
+++ b/src/features/competitions/components/pickemReveal/RevealGroupCard.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { Check, ChevronDown, CircleDashed, X } from "lucide-react";
+import Image from "next/image";
+import { useLocale, useTranslations } from "next-intl";
+
+import type { ResolvedGroupPick } from "@/features/pickems/types/pickems.types";
+import { getAccuracyPillClass } from "@/features/standings/lib/comparison";
+import type { PickAccuracy } from "@/features/standings/types/standings.types";
+import { getTeamName } from "@/shared/lib/getTeamName";
+import { cn } from "@/shared/lib/utils";
+import type { Team } from "@/shared/types/wcp.types";
+
+import type { GroupRevealData, GroupSummary } from "../../lib/pickemRevealCompare";
+
+type Props = {
+  group: ResolvedGroupPick;
+  // Graded rows in actual order, once the group has results. Absent / un-decided →
+  // the card shows the member's predicted order only (no scoring overlay).
+  data?: GroupRevealData;
+  // Controlled by the parent so an expand-all / collapse-all toggle can drive every
+  // card; the header (group + points) always shows, the rows expand on demand.
+  open: boolean;
+  onToggle: () => void;
+};
+
+// Expandable read-only group card. The header always shows the group and — once
+// scored — the points earned, mirroring `/standings` (minus the matchday). Expand
+// to see the rows: actual finishing order with the member's pick as an
+// accuracy-coloured position circle (green exact / amber top-2 / red miss / "—").
+export function RevealGroupCard({ group, data, open, onToggle }: Props) {
+  const t = useTranslations("standings");
+  const tReveal = useTranslations("competitions.memberPickem");
+  const locale = useLocale();
+  const decided = data?.decided ?? false;
+  const summary = data?.summary ?? null;
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-muted"
+      >
+        <span className="flex items-baseline gap-1.5">
+          <span className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">{t("groupLabel")}</span>
+          <span className="text-sm font-bold leading-none text-page-accent">{group.group_code}</span>
+        </span>
+        <span className="flex items-center gap-2">
+          {summary ? <PointsBadge summary={summary} label={tReveal("groupBadge", summary)} /> : null}
+          <ChevronDown className={cn("size-4 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} aria-hidden />
+        </span>
+      </button>
+
+      <ul className={cn("border-t border-border", !open && "hidden")}>
+        {decided
+          ? data!.rows.map((row) => (
+              <Row
+                key={row.team.fifa_code}
+                team={row.team}
+                position={row.actualPosition}
+                locale={locale}
+                pick={{ predicted: row.predictedPosition, accuracy: row.accuracy }}
+              />
+            ))
+          : group.teams.map((team, idx) => <Row key={team.fifa_code} team={team} position={idx + 1} locale={locale} badge={badgeFor(idx + 1)} />)}
+      </ul>
+    </div>
+  );
+}
+
+// Correct positions + points earned, like the `/standings` group badge. A perfect
+// group (every position exact) gets the lime tone and a star.
+function PointsBadge({ summary, label }: { summary: GroupSummary; label: string }) {
+  const isPerfect = summary.total > 0 && summary.correct === summary.total;
+  return (
+    <span
+      className={cn(
+        "rounded-full border px-2 py-0.5 text-2xs font-semibold tabular-nums",
+        isPerfect ? "border-lime-500/30 bg-lime-500/15 text-lime-700 dark:text-lime-400" : "border-border bg-muted text-muted-foreground"
+      )}
+    >
+      {isPerfect ? "★ " : ""}
+      {label}
+    </span>
+  );
+}
+
+function Row({
+  team,
+  position,
+  locale,
+  pick,
+  badge,
+}: {
+  team: Team;
+  position: number;
+  locale: string;
+  pick?: { predicted: number | null; accuracy: PickAccuracy };
+  badge?: BadgeVariant | null;
+}) {
+  return (
+    <li className="flex items-center gap-2 border-t border-border px-2 py-1 first:border-t-0">
+      <span className="w-4 text-center text-2xs tabular-nums text-muted-foreground">{position}</span>
+      <Image src={team.flag_url} alt="" width={20} height={14} className="h-3.5 w-5 shrink-0 rounded-xs object-cover" unoptimized />
+      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">{getTeamName(team, locale)}</span>
+      {pick ? (
+        <span
+          className={cn(
+            "inline-flex h-5 min-w-5 items-center justify-center rounded-full border px-1 text-2xs font-semibold tabular-nums",
+            getAccuracyPillClass(pick.accuracy)
+          )}
+        >
+          {pick.predicted ?? "—"}
+        </span>
+      ) : badge ? (
+        <PositionBadge variant={badge} />
+      ) : null}
+    </li>
+  );
+}
+
+type BadgeVariant = "qualify" | "third" | "out";
+
+function badgeFor(position: number): BadgeVariant | null {
+  if (position === 1 || position === 2) return "qualify";
+  if (position === 3) return "third";
+  if (position === 4) return "out";
+  return null;
+}
+
+// Prediction-only badge in the data-accent palette — mirrors the editable picker.
+function PositionBadge({ variant }: { variant: BadgeVariant }) {
+  const t = useTranslations("pickems.groups.badges");
+  return (
+    <span role="img" aria-label={t(variant)} className="inline-flex size-5 items-center justify-center">
+      {variant === "qualify" && <Check className="size-3.5 text-page-accent-strong" aria-hidden />}
+      {variant === "third" && <CircleDashed className="size-3.5 text-page-accent-strong" aria-hidden />}
+      {variant === "out" && <X className="size-3 text-muted-foreground/70" aria-hidden />}
+    </span>
+  );
+}

--- a/src/features/competitions/lib/memberPickemUrl.ts
+++ b/src/features/competitions/lib/memberPickemUrl.ts
@@ -1,0 +1,11 @@
+import { displayName } from "@/shared/lib/ui";
+
+import type { LeaderboardMember } from "../types/competitions.types";
+
+// Deep link to a member's revealed tournament pick'em. The display name (`n`) and
+// handle (`u`) ride along so the page header titles itself correctly even before
+// the roster/leaderboard lookup resolves (or when the member sits past its window).
+export function memberPickemPath(boardId: number, competitionId: number, member: LeaderboardMember): string {
+  const params = new URLSearchParams({ n: displayName(member.username, member.first_name, member.last_name), u: member.username });
+  return `/boards/${boardId}/competitions/${competitionId}/members/${member.user_id}?${params.toString()}`;
+}

--- a/src/features/competitions/lib/pickemRevealCompare.test.ts
+++ b/src/features/competitions/lib/pickemRevealCompare.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import { buildComparisonMap, summarizeBracket } from "@/features/bracket/lib/bracketCompare";
+import type { BracketMatchSlot, BracketStageCode, RankedTeam, ResolvedGroupPick } from "@/features/pickems/types/pickems.types";
+import type { StandingRow } from "@/features/standings/types/standings.types";
+import type { GroupCode, Team } from "@/shared/types/wcp.types";
+
+import { buildBracketReveal, buildGroupReveal, buildThirdsReveal } from "./pickemRevealCompare";
+
+// ---------------------------------------------------------------------------
+// Fixtures — a tournament at the semifinal stage:
+//   • all 12 groups have played their 3 matchdays (final tables),
+//   • the R32, R16 and QF are decided, the two semifinals are in progress.
+// ---------------------------------------------------------------------------
+
+const GROUP_CODES: GroupCode[] = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"];
+
+function team(code: string, group: GroupCode | null = null): Team {
+  return { fifa_code: code, name: { en: code }, flag_url: "", group_code: group };
+}
+
+function standing(t: Team, position: number, points: number): StandingRow {
+  return { team: t, position, matches_played: 3, wins: 0, draws: 0, losses: 0, goals_for: points, goals_against: 0, goal_difference: points, points };
+}
+
+function ranked(code: string, group: GroupCode, position: number): RankedTeam {
+  return { fifa_code: code, name: { en: code }, flag_url: "", group_code: group, position };
+}
+
+// Final group tables. Third-placed teams get a cross-group points gradient
+// (A3 highest … L3 lowest) so the best-thirds ranking is deterministic: A3–H3
+// advance, I3–L3 miss the cut.
+const standings: StandingRow[] = GROUP_CODES.flatMap((code, g) => [1, 2, 3, 4].map((pos) => standing(team(`${code}${pos}`, code), pos, pos === 3 ? 12 - g : 5 - pos)));
+
+// The member's group order: group A perfect (4 exact = 12 pts), group B with 1st
+// and 2nd swapped (two top-2 misses +1 each, two exact +3 = 8 pts), the rest exact.
+const groupPicks: ResolvedGroupPick[] = GROUP_CODES.map((code) => {
+  const order = code === "B" ? [2, 1, 3, 4] : [1, 2, 3, 4];
+  return { group_code: code, locked: true, teams: order.map((pos, idx) => ranked(`${code}${pos}`, code, idx + 1)) };
+});
+
+// The member's best-thirds: 7 that advance (A3–G3), plus I3 which misses; they
+// leave out H3 (which advances).
+const bestThirds: Team[] = ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "I3"].map((c) => team(c, c[0] as GroupCode));
+
+// --- Bracket: one fully-decided arm through the QF, into a live semifinal. ----
+function slot(matchId: number, stage: BracketStageCode, home: Team | null, away: Team | null, picked: Team | null): BracketMatchSlot {
+  return { match_id: matchId, stage_code: stage, home_team: home, away_team: away, picked_team: picked };
+}
+
+const A1 = team("A1");
+const B2 = team("B2");
+const C1 = team("C1");
+const D2 = team("D2");
+const E1 = team("E1");
+const G1 = team("G1");
+
+// Reality: A1 wins its R32, R16, QF; the SF is not yet played. In a parallel R32,
+// C1 beats D2.
+const actualBracket: BracketMatchSlot[] = [
+  slot(73, "round_of_32", A1, B2, A1),
+  slot(74, "round_of_32", C1, D2, C1),
+  slot(89, "round_of_16", A1, C1, A1),
+  slot(97, "quarterfinals", A1, E1, A1),
+  slot(101, "semifinals", A1, G1, null), // in progress
+];
+
+// The member: correct on A1's whole run and the R32 matchups, but wrongly picked
+// D2 to win match 74.
+const memberBracket: BracketMatchSlot[] = [
+  slot(73, "round_of_32", A1, B2, A1),
+  slot(74, "round_of_32", C1, D2, D2), // right teams reach R32, wrong winner
+  slot(89, "round_of_16", A1, C1, A1),
+  slot(97, "quarterfinals", A1, E1, A1),
+  slot(101, "semifinals", A1, G1, A1),
+];
+
+describe("group reveal at the semifinal stage", () => {
+  const reveal = buildGroupReveal(groupPicks, standings, true);
+
+  it("grades every group as decided once the group stage is over", () => {
+    expect([...reveal.values()].every((g) => g.decided)).toBe(true);
+  });
+
+  it("awards a perfect group the full 12 points", () => {
+    expect(reveal.get("A")?.summary).toEqual({ correct: 4, total: 4, points: 12, maxPoints: 12 });
+  });
+
+  it("scores a 1st/2nd swap as two top-2 hits + two exact = 8 points", () => {
+    expect(reveal.get("B")?.summary).toEqual({ correct: 2, total: 4, points: 8, maxPoints: 12 });
+  });
+
+  it("orders rows by the actual finishing position", () => {
+    expect(reveal.get("A")?.rows.map((r) => r.actualPosition)).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("best-thirds reveal at the semifinal stage", () => {
+  const reveal = buildThirdsReveal(bestThirds, standings, true);
+  const byCode = new Map(reveal.rows.map((r) => [r.team.fifa_code, r]));
+
+  it("is decided and ranks all twelve thirds, top eight advancing", () => {
+    expect(reveal.decided).toBe(true);
+    expect(reveal.rows).toHaveLength(12);
+    expect(reveal.qualifyingSlots).toBe(8);
+  });
+
+  it("marks a picked team that advanced as correct", () => {
+    expect(byCode.get("A3")).toMatchObject({ picked: true, advances: true, accuracy: "correct" });
+  });
+
+  it("marks a picked team that missed the cut as wrong", () => {
+    expect(byCode.get("I3")).toMatchObject({ picked: true, advances: false, accuracy: "wrong" });
+  });
+
+  it("leaves an unpicked advancer as not-picked", () => {
+    expect(byCode.get("H3")).toMatchObject({ picked: false, advances: true, accuracy: "missed" });
+  });
+});
+
+describe("bracket reveal at the semifinal stage", () => {
+  it("greens every team correctly predicted to REACH a round (incl. the R32 group call)", () => {
+    const map = buildBracketReveal(memberBracket, actualBracket, true);
+    // Match 74: wrong winner pick, but both teams correctly reached the R32 → both green.
+    expect(map.get(74)).toEqual({ homeCorrect: true, awayCorrect: true });
+    // A1 correctly placed through every round it reached.
+    expect(map.get(89)).toMatchObject({ homeCorrect: true });
+    expect(map.get(97)).toMatchObject({ homeCorrect: true });
+    expect(map.get(101)).toMatchObject({ homeCorrect: true });
+  });
+
+  it("shows nothing for a member who never played", () => {
+    const map = buildBracketReveal(memberBracket, actualBracket, false);
+    expect([...map.values()].every((c) => !c.homeCorrect && !c.awayCorrect)).toBe(true);
+  });
+
+  it("scores points only for advancing — R32+R16+QF = 18, the wrong winner earns 0", () => {
+    // Decided: 73 (+4), 74 (+4 wrong → 0), 89 (+6), 97 (+8). SF not played.
+    expect(summarizeBracket(actualBracket, memberBracket)).toMatchObject({ earned: 18, possible: 22 });
+  });
+
+  it("breaks earned / possible down per round for the legend", () => {
+    const { byStage } = summarizeBracket(actualBracket, memberBracket);
+    expect(byStage.get("round_of_32")).toEqual({ earned: 4, possible: 8 }); // 73 right, 74 wrong
+    expect(byStage.get("round_of_16")).toEqual({ earned: 6, possible: 6 });
+    expect(byStage.get("quarterfinals")).toEqual({ earned: 8, possible: 8 });
+  });
+
+  it("does not bracket-score reaching the R32 (that is the group stage's job)", () => {
+    // Only R32 matches exist, none decided → no points possible yet.
+    const onlyR32 = actualBracket.filter((s) => s.stage_code === "round_of_32").map((s) => ({ ...s, picked_team: null }));
+    expect(summarizeBracket(onlyR32, memberBracket)).toMatchObject({ earned: 0, possible: 0 });
+  });
+
+  it("agrees with /bracket compare on the actual tree (reach-based greens)", () => {
+    const map = buildComparisonMap(actualBracket, memberBracket);
+    // On the real tree, A1 is greened wherever the member predicted it to reach.
+    expect(map.get(73)).toMatchObject({ homeCorrect: true });
+    expect(map.get(89)).toMatchObject({ homeCorrect: true });
+  });
+});

--- a/src/features/competitions/lib/pickemRevealCompare.ts
+++ b/src/features/competitions/lib/pickemRevealCompare.ts
@@ -1,0 +1,129 @@
+import { buildComparisonMap } from "@/features/bracket/lib/bracketCompare";
+import type { SlotComparison } from "@/features/bracket/types/bracket.types";
+import type { BracketMatchSlot, ResolvedGroupPick } from "@/features/pickems/types/pickems.types";
+import { computeGroupComparison, computeRowComparison, computeThirdPlaceComparison } from "@/features/standings/lib/comparison";
+import { groupAndEnrichStandings } from "@/features/standings/lib/groupStandings";
+import { buildThirdPlaceStandings } from "@/features/standings/lib/thirdPlace";
+import type { PickAccuracy, ThirdPlaceAccuracy, StandingRow } from "@/features/standings/types/standings.types";
+import type { GroupCode, Team } from "@/shared/types/wcp.types";
+
+// Empty pick map for groups the member never locked: every row then resolves to
+// "not picked" (the "—" circle), so a member who made no pick'em scores nothing —
+// exactly how `/standings` compare treats an unlocked group.
+const NO_PICKS: Map<string, number> = new Map();
+
+// One graded row in a decided group — the actual finishing team, plus where the
+// member predicted it (`predictedPosition`) and how that scored (`accuracy`).
+// Mirrors the standings compare row: rows sit in actual order, the member's pick
+// shows as an accuracy-coloured position circle.
+export type GroupRevealRow = {
+  team: Team;
+  actualPosition: number;
+  predictedPosition: number | null;
+  accuracy: PickAccuracy;
+};
+
+// Per-group compare summary shown in the (collapsed) card header — how many
+// positions the member nailed and the points they earned (with the group's max),
+// like `/standings`. `maxPoints` lets the section total an earned / possible tally.
+export type GroupSummary = { correct: number; total: number; points: number; maxPoints: number };
+
+export type GroupRevealData = { decided: boolean; rows: GroupRevealRow[]; summary: GroupSummary | null };
+
+export type GroupReveal = Map<GroupCode, GroupRevealData>;
+
+/**
+ * Score a member's group-stage order against the actual standings. A group is
+ * `decided` only once it has played all its matchdays — until then the table is
+ * provisional, so we leave it un-graded (the card falls back to the member's
+ * predicted order). When decided, rows come back in *actual* order so the
+ * predicted-position circle reads against the final table.
+ *
+ * `scored` is the authoritative gate: the board's leaderboard is the source of
+ * truth for points, and the member endpoint hands back a fully-seeded, locked
+ * pickem even for members who never really played. When the board credited the
+ * member no group points we treat every pick as "not picked" → "—", so the reveal
+ * never shows points the board didn't actually award.
+ */
+export function buildGroupReveal(groupPicks: ResolvedGroupPick[], standings: StandingRow[], scored: boolean): GroupReveal {
+  const reveal: GroupReveal = new Map();
+  const enriched = groupAndEnrichStandings(standings);
+  const byGroupActual = new Map(enriched.map((g) => [g.group_code, g] as const));
+
+  for (const pick of groupPicks) {
+    const actualGroup = byGroupActual.get(pick.group_code);
+    // Only grade a *finished* group — provisional positions would show points that
+    // shift as the group plays out and wouldn't reconcile with the board total.
+    const decided = actualGroup ? actualGroup.matchday >= actualGroup.total_matchdays : false;
+
+    if (!actualGroup || !decided) {
+      reveal.set(pick.group_code, { decided: false, rows: [], summary: null });
+      continue;
+    }
+
+    const pickMap = scored && pick.locked ? new Map(pick.teams.map((t) => [t.fifa_code, t.position])) : NO_PICKS;
+    const rows: GroupRevealRow[] = actualGroup.rows.map((row) => {
+      const { predicted_position, accuracy } = computeRowComparison(row, pickMap);
+      return { team: row.team, actualPosition: row.position, predictedPosition: predicted_position, accuracy };
+    });
+
+    // Only summarise a group the member actually scored — a non-scorer's header
+    // stays clean (no "0 pts" badge) since their picks read as "—".
+    const c = pickMap.size > 0 ? computeGroupComparison(actualGroup.rows, pickMap) : null;
+    const summary = c ? { correct: c.correct, total: c.total, points: c.points, maxPoints: c.maxPoints } : null;
+
+    reveal.set(pick.group_code, { decided: true, rows, summary });
+  }
+
+  return reveal;
+}
+
+// One row of the cross-group third-place ranking, graded against the member's
+// best-thirds picks: `accuracy` drives the same ✓ / ✕ / — circle as standings.
+export type ThirdRevealRow = {
+  team: Team;
+  rank: number;
+  advances: boolean;
+  picked: boolean;
+  accuracy: ThirdPlaceAccuracy;
+};
+
+export type ThirdsReveal = { decided: boolean; rows: ThirdRevealRow[]; qualifyingSlots: number };
+
+/**
+ * Rank the twelve third-placed teams and grade them against the member's
+ * best-thirds picks. Only meaningful once the whole group stage has finished (the
+ * cross-group ranking is provisional until then), so `decided` gates on every
+ * group having played all its matchdays. `scored` is the same authoritative gate
+ * as `buildGroupReveal`: when the board credited the member no best-third points,
+ * every row resolves to "not picked" (`—`).
+ */
+export function buildThirdsReveal(bestThirds: Team[], standings: StandingRow[], scored: boolean): ThirdsReveal {
+  const enriched = groupAndEnrichStandings(standings);
+  const decided = enriched.length > 0 && enriched.every((g) => g.matchday >= g.total_matchdays);
+  const third = buildThirdPlaceStandings(enriched);
+  const pickedSet = scored ? new Set(bestThirds.map((team) => team.fifa_code)) : new Set<string>();
+
+  const rows: ThirdRevealRow[] = third.rows.map((row) => {
+    const { picked, accuracy } = computeThirdPlaceComparison(row, pickedSet);
+    return { team: row.team, rank: row.third_place_rank, advances: row.advances, picked, accuracy };
+  });
+
+  return { decided, rows, qualifyingSlots: third.qualifying_slots };
+}
+
+/**
+ * Grade the member's *predicted* bracket against reality, keyed by predicted match
+ * id, so the reveal greens the teams they correctly predicted to reach each round
+ * — including the Round of 32 (a correct group call) even though that scores no
+ * bracket points. `buildComparisonMap` on the member's own tree does exactly this.
+ *
+ * `participated` is the gate: the seeded member endpoint hands back a default tree
+ * even for non-players, so we only light it up once the member has earned points
+ * somewhere. The all-false map keeps the cards in compare mode (their picks shown,
+ * but no checks and no pick accent).
+ */
+export function buildBracketReveal(predicted: BracketMatchSlot[], actual: BracketMatchSlot[], participated: boolean): Map<number, SlotComparison> {
+  if (!participated) return new Map(predicted.map((slot) => [slot.match_id, { homeCorrect: false, awayCorrect: false }]));
+  return buildComparisonMap(predicted, actual);
+}

--- a/src/i18n/messages/bracket/en.json
+++ b/src/i18n/messages/bracket/en.json
@@ -14,8 +14,8 @@
     "title": "Compare",
     "pointsLabel": "pts",
     "earnedPossible": "Earned / possible",
-    "correct": "Your correct pick",
-    "correctHelp": "a team you predicted to reach that round",
-    "scoringTitle": "Points per round reached"
+    "correct": "Correct pick",
+    "correctHelp": "a team you correctly predicted to reach this round",
+    "scoringTitle": "Points for advancing past a round"
   }
 }

--- a/src/i18n/messages/bracket/es.json
+++ b/src/i18n/messages/bracket/es.json
@@ -14,8 +14,8 @@
     "title": "Comparación",
     "pointsLabel": "pts",
     "earnedPossible": "Ganados / posibles",
-    "correct": "Tu acierto",
-    "correctHelp": "equipo que pronosticaste para llegar a esa ronda",
-    "scoringTitle": "Puntos por ronda alcanzada"
+    "correct": "Acierto",
+    "correctHelp": "equipo que pronosticaste correctamente para llegar a esta ronda",
+    "scoringTitle": "Puntos por avanzar de una ronda"
   }
 }

--- a/src/i18n/messages/competitions/en.json
+++ b/src/i18n/messages/competitions/en.json
@@ -194,6 +194,46 @@
       "points": "points"
     }
   },
+  "memberPickem": {
+    "back": "Back to competition",
+    "score": {
+      "total": "Total points"
+    },
+    "tabs": {
+      "groups": "Group stage",
+      "knockout": "Knockout"
+    },
+    "expandAll": "Expand all",
+    "collapseAll": "Collapse all",
+    "groupBadge": "{correct}/{total} · {points} pts",
+    "groupsLegend": {
+      "title": "How to read · Groups",
+      "help": "The position they picked, scored against the real table",
+      "exact": "Exact position (+3 pts)",
+      "top2": "Top 2, wrong order (+1 pt)",
+      "wrong": "Wrong (0 pts)",
+      "notPicked": "Not picked",
+      "pointsLabel": "pts",
+      "earnedPossible": "Earned / possible"
+    },
+    "thirdsLegend": {
+      "title": "How to read · Best thirds",
+      "help": "Did their pick make the top 8?",
+      "correct": "Picked and advanced (+2 pts)",
+      "wrong": "Picked but missed the cut (0 pts)",
+      "notPicked": "Not picked"
+    },
+    "sections": {
+      "groups": "Group stage",
+      "thirds": "Best thirds",
+      "bracket": "Knockout bracket"
+    },
+    "thirdsEmpty": "No best-third picks",
+    "locked": {
+      "title": "Predictions aren't revealed yet",
+      "description": "They unlock once the tournament kicks off."
+    }
+  },
   "emptyCompetitions": {
     "title": "No competitions yet",
     "descriptionAdmin": "Create the first custom competition or pick for this board.",

--- a/src/i18n/messages/competitions/es.json
+++ b/src/i18n/messages/competitions/es.json
@@ -194,6 +194,46 @@
       "points": "puntos"
     }
   },
+  "memberPickem": {
+    "back": "Volver a la competencia",
+    "score": {
+      "total": "Puntos totales"
+    },
+    "tabs": {
+      "groups": "Fase de grupos",
+      "knockout": "Eliminatorias"
+    },
+    "expandAll": "Expandir todo",
+    "collapseAll": "Contraer todo",
+    "groupBadge": "{correct}/{total} · {points} pts",
+    "groupsLegend": {
+      "title": "Cómo leer · Grupos",
+      "help": "La posición que eligió, comparada con la tabla real",
+      "exact": "Posición exacta (+3 pts)",
+      "top2": "Top 2, orden incorrecto (+1 pt)",
+      "wrong": "Incorrecto (0 pts)",
+      "notPicked": "Sin elegir",
+      "pointsLabel": "pts",
+      "earnedPossible": "Ganados / posibles"
+    },
+    "thirdsLegend": {
+      "title": "Cómo leer · Mejores terceros",
+      "help": "¿Su elegido entró al top 8?",
+      "correct": "Elegido y clasificó (+2 pts)",
+      "wrong": "Elegido pero quedó fuera (0 pts)",
+      "notPicked": "Sin elegir"
+    },
+    "sections": {
+      "groups": "Fase de grupos",
+      "thirds": "Mejores terceros",
+      "bracket": "Llave eliminatoria"
+    },
+    "thirdsEmpty": "Sin terceros elegidos",
+    "locked": {
+      "title": "Los pronósticos aún no se revelan",
+      "description": "Se revelan en cuanto arranca el torneo."
+    }
+  },
   "emptyCompetitions": {
     "title": "Aún no hay competencias",
     "descriptionAdmin": "Crea la primera competencia personalizada o polla de este tablero.",

--- a/src/i18n/messages/layout/en.json
+++ b/src/i18n/messages/layout/en.json
@@ -164,10 +164,10 @@
         "heading": "Knockout bracket points",
         "items": {
           "bestThird": { "label": "Best third-place", "description": "Per correct team in the 8 best-thirds list" },
-          "r32": { "label": "Round of 32", "description": "Per correct team that reaches this round" },
-          "r16": { "label": "Round of 16", "description": "Per correct team that reaches this round" },
-          "quarterfinals": { "label": "Quarterfinals", "description": "Per correct team that reaches this round" },
-          "semifinals": { "label": "Semifinals", "description": "Per correct team that reaches this round" },
+          "r32": { "label": "Round of 32", "description": "Per correct team that advances from this round" },
+          "r16": { "label": "Round of 16", "description": "Per correct team that advances from this round" },
+          "quarterfinals": { "label": "Quarterfinals", "description": "Per correct team that advances from this round" },
+          "semifinals": { "label": "Semifinals", "description": "Per correct team that advances from this round" },
           "thirdPlace": { "label": "Third-place match", "description": "Correct third-place winner" },
           "final": { "label": "Final (champion)", "description": "Correct tournament winner" }
         }

--- a/src/i18n/messages/layout/es.json
+++ b/src/i18n/messages/layout/es.json
@@ -164,10 +164,10 @@
         "heading": "Eliminatorias",
         "items": {
           "bestThird": { "label": "Mejor tercero", "description": "Por cada equipo correcto entre los 8 mejores terceros" },
-          "r32": { "label": "Dieciseisavos", "description": "Por equipo acertado que alcanza esta ronda" },
-          "r16": { "label": "Octavos de final", "description": "Por equipo acertado que alcanza esta ronda" },
-          "quarterfinals": { "label": "Cuartos de final", "description": "Por equipo acertado que alcanza esta ronda" },
-          "semifinals": { "label": "Semifinales", "description": "Por equipo acertado que alcanza esta ronda" },
+          "r32": { "label": "Dieciseisavos", "description": "Por equipo acertado que avanza de esta ronda" },
+          "r16": { "label": "Octavos de final", "description": "Por equipo acertado que avanza de esta ronda" },
+          "quarterfinals": { "label": "Cuartos de final", "description": "Por equipo acertado que avanza de esta ronda" },
+          "semifinals": { "label": "Semifinales", "description": "Por equipo acertado que avanza de esta ronda" },
           "thirdPlace": { "label": "Tercer puesto", "description": "Acertaste al ganador del partido por el tercer puesto" },
           "final": { "label": "Final (campeón)", "description": "Acertaste al campeón del torneo" }
         }


### PR DESCRIPTION
## Release v1.5.0

Reveals a board member's full tournament pick'em so other members can compare predictions.

### Highlights
- **Competitions:** Board members can now view any member's tournament pick'em selections, surfacing their bracket predictions across all rounds